### PR TITLE
Bin connecting

### DIFF
--- a/macros/compile.sh
+++ b/macros/compile.sh
@@ -3,7 +3,7 @@
 # -------------------------------------------------#
 # Bash script for compiling the processor of the
 # analysis.
-# To be run simply by using: ./run_make.sh [-rebuild]
+# To be run simply by using: ./compile.sh [-rebuild]
 # Be sure a modern software is sourced! (E.g. sourcing load_env.sh)
 # -------------------------------------------------#
 

--- a/source/prew/include/Connect/DataConnector.h
+++ b/source/prew/include/Connect/DataConnector.h
@@ -1,0 +1,58 @@
+#ifndef LIB_DATACONNECTOR_H
+#define LIB_DATACONNECTOR_H 1
+
+#include <Data/CoefDistr.h>
+#include <Data/DiffDistr.h>
+#include <Data/PolLink.h>
+#include <Data/PredDistr.h>
+#include <Data/PredLink.h>
+#include <Fit/FitContainer.h>
+
+namespace PREW {
+namespace Connect {
+  
+  class DataConnector {
+    /** Class that stores all the information supplied by input files and
+        instructions and uses it to form fitable bins from given distributions.
+    **/
+    
+    // Store predictions, coefficients and linking instructions
+    // => Everything that is needed to properly connect bins of a distribution
+    Data::PredDistrVec m_pred_distrs {};
+    Data::CoefDistrVec m_coef_distrs {};
+    Data::PredLinkVec  m_pred_links {};
+    Data::PolLinkVec   m_pol_links {};
+    
+    public:
+      // Constructor
+      DataConnector (
+        Data::PredDistrVec pred_distrs = {},
+        Data::CoefDistrVec coef_distrs = {},
+        Data::PredLinkVec  pred_links  = {},
+        Data::PolLinkVec   pol_links   = {}
+      );
+      
+      // Core functionality: providing connected bins
+      void fill_bins(
+        const Data::DiffDistr & diff_distr,
+        Fit::ParVec *pars,
+        Fit::BinVec *bins
+      ) const;
+      
+      void fill_fit_container(
+        const Data::DiffDistrVec & diff_distrs,
+        const Fit::ParVec        & pars,
+        Fit::FitContainer *fit_container 
+      ) const;
+      
+      // Read functions
+      const Data::PredDistrVec& get_pred_distrs() const;
+      const Data::CoefDistrVec& get_coef_distrs() const;
+      const Data::PredLinkVec&  get_pred_links() const;
+      const Data::PolLinkVec&   get_pol_links() const;
+  };
+  
+}
+}
+
+#endif

--- a/source/prew/include/Connect/LinkHelp.h
+++ b/source/prew/include/Connect/LinkHelp.h
@@ -1,0 +1,32 @@
+#ifndef LIB_LINKHELP_H
+#define LIB_LINKHELP_H 1
+
+#include <Fit/FitPar.h>
+
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace PREW {
+namespace Connect {
+  
+namespace LinkHelp {
+  /** Functions that help with the linking of predictions.
+  **/
+  
+  std::function<double()> get_polfactor_lambda(
+    const std::string                         & chirality, 
+    const std::pair<std::string, std::string> & pol_pair, 
+    Fit::ParVec *pars
+  );
+  
+  double get_modified_sigma(
+    double sigma,
+    const std::vector<std::function<double()>>& alphas
+  );
+}
+
+}
+}
+
+#endif

--- a/source/prew/include/Connect/LinkHelp.h
+++ b/source/prew/include/Connect/LinkHelp.h
@@ -20,7 +20,7 @@ namespace LinkHelp {
     Fit::ParVec *pars
   );
   
-  double get_modified_sigma(
+  std::function<double()> get_modified_sigma(
     double sigma,
     const std::vector<std::function<double()>>& alphas
   );

--- a/source/prew/include/Connect/Linker.h
+++ b/source/prew/include/Connect/Linker.h
@@ -36,6 +36,11 @@ namespace Connect {
         size_t bin,
         Fit::ParVec *pars
       ) const;
+      
+      std::vector<std::function<double()>> get_all_bonded_fncts_at_bin(
+        size_t bin,
+        Fit::ParVec *pars
+      ) const;
   };
   
 }

--- a/source/prew/include/Connect/Linker.h
+++ b/source/prew/include/Connect/Linker.h
@@ -1,0 +1,44 @@
+#ifndef LIB_LINKER_H
+#define LIB_LINKER_H 1
+
+#include <CppUtils/Vec.h>
+#include <Data/CoefDistr.h>
+#include <Data/FnctLink.h>
+#include <Fit/FitPar.h>
+#include <Fncts/FnctMap.h>
+
+#include <functional>
+#include <string>
+
+namespace PREW {
+namespace Connect {
+
+  class Linker {
+    /** Class that takes all the info about how functions for one particular
+        distribution are supposed to be bound and can give the functions for 
+        each bin of the distribution.
+    **/
+    
+    Data::FnctLinkVec m_fncts_links {};
+    CppUtils::Vec::Matrix2D<double> m_bin_centers {};
+    Data::CoefDistrVec m_coefs {};
+    
+    public:
+      // Constructors
+      Linker( Data::FnctLinkVec fncts_links,
+              CppUtils::Vec::Matrix2D<double> bin_centers,
+              Data::CoefDistrVec coefs
+             );
+      
+      // Core functionality
+      std::function<double()> get_bonded_fnct_at_bin(
+        const std::string &fnct_name,
+        size_t bin,
+        Fit::ParVec *pars
+      ) const;
+  };
+  
+}
+}
+
+#endif

--- a/source/prew/include/CppUtils/Fnct.h
+++ b/source/prew/include/CppUtils/Fnct.h
@@ -1,0 +1,25 @@
+#ifndef LIB_CPPHELPFNCT_H
+#define LIB_CPPHELPFNCT_H 1
+
+#include <functional>
+#include <vector>
+
+namespace PREW {
+namespace CppUtils {
+
+namespace Fnct {
+  /** Namespace for C++ helper functions and classes related to std::function.
+  **/
+  
+  // Function which has three input parameter vectors,
+  // In PrEW like: coordinates,parameters,coefficients
+  using ParametrisationFnct = std::function<double(const std::vector<double> &,
+                                                   const std::vector<double> &,
+                                                   const std::vector<double*> &)
+                                            >;
+}
+
+}
+}
+
+#endif

--- a/source/prew/include/CppUtils/Map.h
+++ b/source/prew/include/CppUtils/Map.h
@@ -1,0 +1,25 @@
+#ifndef LIB_CPPHELPMAP_H
+#define LIB_CPPHELPMAP_H 1
+
+#include <map>
+#include <set>
+#include <vector>
+
+namespace PREW {
+namespace CppUtils {
+
+namespace Map {
+  using StrToStrVecMap  = std::map<std::string,std::vector<std::string>>;
+  using StrToStrPairMap = 
+    std::map<std::string, std::pair<std::string, std::string>>;
+  
+  using DoubleToStrVecMap = std::map<double, std::vector<std::string>>;
+  using IntToStrVecMap    = std::map<int, std::vector<std::string>>;
+  
+  using IntToStrSetMap = std::map<int, std::set<std::string>>;
+}
+
+}
+}
+
+#endif

--- a/source/prew/include/CppUtils/Str.h
+++ b/source/prew/include/CppUtils/Str.h
@@ -1,0 +1,18 @@
+#ifndef LIB_CPPHELPSTR_H
+#define LIB_CPPHELPSTR_H 1
+
+#include <string>
+#include <vector>
+
+namespace PREW {
+namespace CppUtils {
+
+namespace Str {
+  std::vector<std::string> string_to_vec( const std::string &str, 
+                                          std::string delimiter=" ");
+}
+
+}
+}
+
+#endif

--- a/source/prew/include/CppUtils/Vec.h
+++ b/source/prew/include/CppUtils/Vec.h
@@ -1,6 +1,7 @@
 #ifndef LIB_CPPHELPVEC_H
 #define LIB_CPPHELPVEC_H 1
 
+#include <functional>
 #include <vector>
 
 namespace PREW {
@@ -8,9 +9,17 @@ namespace CppUtils {
 
 namespace Vec {
   template <class T> using Matrix2D = std::vector<std::vector<T>>;
+  
+  template <class T, class F>
+  std::vector<T> subvec_by_condition( const std::vector<T> &vec, 
+                                      F &condition );
+  template <class T, class F>
+  T element_by_condition( const std::vector<T> &vec, F &condition );
 }
 
 }
 }
+
+#include <CppUtils/Vec.tpp>
 
 #endif

--- a/source/prew/include/CppUtils/Vec.tpp
+++ b/source/prew/include/CppUtils/Vec.tpp
@@ -1,0 +1,43 @@
+#ifndef LIB_CPPHELPVEC_TPP
+#define LIB_CPPHELPVEC_TPP 1
+
+#include <CppUtils/Vec.h>
+
+namespace PREW {
+namespace CppUtils {
+
+//------------------------------------------------------------------------------
+
+template <class T, class F>
+std::vector<T> Vec::subvec_by_condition( 
+  const std::vector<T> &vec, 
+  F &condition
+) {
+  /** Find a subvector of vec in which all elements return true on the given 
+      condition function.
+  **/
+  std::vector<T> subvec (vec.size());
+  // Copy all elements that fulfill the condition
+  auto it = std::copy_if( vec.begin(), vec.end(), subvec.begin(), 
+                          condition );
+  subvec.resize(std::distance(subvec.begin(),it)); // Crop empty end of subvec
+  return subvec;
+}
+
+//------------------------------------------------------------------------------
+
+template <class T, class F>
+T Vec::element_by_condition( const std::vector<T> &vec, F &condition ) {
+  /** Find and return the first element in the vector that fulfills the given
+      condition (i.e. returns true when condition function is called).
+  **/
+  auto it = std::find_if( vec.begin(), vec.end(), condition );
+  return *it;
+}
+
+//------------------------------------------------------------------------------
+
+}
+}
+
+#endif

--- a/source/prew/include/Data/CoefDistr.h
+++ b/source/prew/include/Data/CoefDistr.h
@@ -11,7 +11,7 @@ namespace Data {
 
   struct CoefDistr {
     /** Class holding a coefficient for parameterised prediction of a 
-        distribution for one process & polarisation/chirality.
+        distribution for one polarisation/chirality.
     **/
     
     std::string m_coef_name {}; // Name that identifies this coefficient

--- a/source/prew/include/Data/CoefDistr.h
+++ b/source/prew/include/Data/CoefDistr.h
@@ -4,6 +4,7 @@
 #include <Data/DistrInfo.h>
 
 #include <string>
+#include <vector>
 
 namespace PREW {
 namespace Data {

--- a/source/prew/include/Data/CoefDistr.h
+++ b/source/prew/include/Data/CoefDistr.h
@@ -1,0 +1,28 @@
+#ifndef LIBRARY_COEFDISTR_H
+#define LIBRARY_COEFDISTR_H 1
+
+#include <Data/DistrInfo.h>
+
+#include <string>
+
+namespace PREW {
+namespace Data {
+
+  struct CoefDistr {
+    /** Class holding a coefficient for parameterised prediction of a 
+        distribution for one process & polarisation/chirality.
+    **/
+    
+    std::string m_coef_name {}; // Name that identifies this coefficient
+    DistrInfo m_info {}; // Info which identifies the corresponding distribution
+    
+    // Coefficient for each bin
+    std::vector<double> m_coefficients {};
+  };
+  
+  typedef std::vector<CoefDistr> CoefDistrVec;
+    
+}
+}
+
+#endif

--- a/source/prew/include/Data/DiffDistr.h
+++ b/source/prew/include/Data/DiffDistr.h
@@ -1,5 +1,5 @@
-#ifndef LIBRARY_DISTR1D_H
-#define LIBRARY_DISTR1D_H 1
+#ifndef LIBRARY_DIFFDISTR_H
+#define LIBRARY_DIFFDISTR_H 1
 
 #include <CppUtils/Vec.h>
 #include <Data/DistrInfo.h>
@@ -9,7 +9,7 @@
 namespace PREW {
 namespace Data {
   
-  struct Distr1D {
+  struct DiffDistr {
     /** Class holding a differential distribution of a process for a 
         polarisation combination.
         -> Save all (necessary) information directly with distribution
@@ -25,7 +25,7 @@ namespace Data {
     Fit::BinVec m_distribution {}; // Observable values (e.g. cross section)
   };
   
-  typedef std::vector<Distr1D> Distr1DVec;
+  typedef std::vector<DiffDistr> DiffDistrVec;
 }
 }
 

--- a/source/prew/include/Data/DiffDistr.h
+++ b/source/prew/include/Data/DiffDistr.h
@@ -12,8 +12,10 @@ namespace Data {
   struct DiffDistr {
     /** Class holding a differential distribution of a process for a 
         polarisation combination.
-        -> Save all (necessary) information directly with distribution
-           (Distributions with common arguments can be found easily)
+        Differential distributions can only be distributions of numbers of 
+        events in the context of this framework. Everything else (e.g cross 
+        section) would carry a systematic error that this framework is not made
+        to account for.
     **/
     
     DistrInfo m_info {}; // Info which identifies this distribution
@@ -22,7 +24,7 @@ namespace Data {
     // => Are not stored with the bin because underlying fit framework 
     //    doesn't need it
     CppUtils::Vec::Matrix2D<double> m_bin_centers {}; 
-    Fit::BinVec m_distribution {}; // Observable values (e.g. cross section)
+    Fit::BinVec m_distribution {}; // Distribution of number of events
   };
   
   typedef std::vector<DiffDistr> DiffDistrVec;

--- a/source/prew/include/Data/DiffDistr.h
+++ b/source/prew/include/Data/DiffDistr.h
@@ -10,8 +10,8 @@ namespace PREW {
 namespace Data {
   
   struct DiffDistr {
-    /** Class holding a differential distribution of a process for a 
-        polarisation combination.
+    /** Class holding a differential distribution for one polarisation 
+        combination.
         Differential distributions can only be distributions of numbers of 
         events in the context of this framework. Everything else (e.g cross 
         section) would carry a systematic error that this framework is not made

--- a/source/prew/include/Data/Distr1D.h
+++ b/source/prew/include/Data/Distr1D.h
@@ -1,8 +1,9 @@
 #ifndef LIBRARY_DISTR1D_H
 #define LIBRARY_DISTR1D_H 1
 
-#include <Fit/FitBin.h>
 #include <CppUtils/Vec.h>
+#include <Data/DistrInfo.h>
+#include <Fit/FitBin.h>
 
 
 namespace PREW {
@@ -15,10 +16,7 @@ namespace Data {
            (Distributions with common arguments can be found easily)
     **/
     
-    std::string m_process_name {};  // Name of process
-    std::string m_distr_name {};    // Name of distribution
-    std::string m_pol_config {};    // Name of polarisation setting
-    double      m_energy {};        // Center of mass energy
+    DistrInfo m_info {}; // Info which identifies this distribution
     
     // Values of observables at bin center
     // => Are not stored with the bin because underlying fit framework 

--- a/source/prew/include/Data/DistrInfo.h
+++ b/source/prew/include/Data/DistrInfo.h
@@ -1,5 +1,5 @@
-#ifndef LIBRARY_DISTRINFO_H
-#define LIBRARY_DISTRINFO_H 1
+#ifndef LIB_DISTRINFO_H
+#define LIB_DISTRINFO_H 1
 
 #include <string>
 
@@ -12,6 +12,8 @@ namespace Data {
     std::string m_distr_name {};    // Name of distribution
     std::string m_pol_config {};    // Name of polarisation setting
     int         m_energy {};        // Center of mass energy
+    
+    bool operator==(const DistrInfo& other) const;
   };
   
 }

--- a/source/prew/include/Data/DistrInfo.h
+++ b/source/prew/include/Data/DistrInfo.h
@@ -9,7 +9,6 @@ namespace Data {
   struct DistrInfo {
     /** Identifier holding all the info that uniquely identifies a distribution.
     **/
-    std::string m_process_name {};  // Name of process
     std::string m_distr_name {};    // Name of distribution
     std::string m_pol_config {};    // Name of polarisation setting
     int         m_energy {};        // Center of mass energy

--- a/source/prew/include/Data/DistrInfo.h
+++ b/source/prew/include/Data/DistrInfo.h
@@ -12,7 +12,7 @@ namespace Data {
     std::string m_process_name {};  // Name of process
     std::string m_distr_name {};    // Name of distribution
     std::string m_pol_config {};    // Name of polarisation setting
-    double      m_energy {};        // Center of mass energy
+    int         m_energy {};        // Center of mass energy
   };
   
 }

--- a/source/prew/include/Data/DistrInfo.h
+++ b/source/prew/include/Data/DistrInfo.h
@@ -1,6 +1,8 @@
 #ifndef LIBRARY_DISTRINFO_H
 #define LIBRARY_DISTRINFO_H 1
 
+#include <string>
+
 namespace PREW {
 namespace Data {
 

--- a/source/prew/include/Data/DistrInfo.h
+++ b/source/prew/include/Data/DistrInfo.h
@@ -1,0 +1,19 @@
+#ifndef LIBRARY_DISTRINFO_H
+#define LIBRARY_DISTRINFO_H 1
+
+namespace PREW {
+namespace Data {
+
+  struct DistrInfo {
+    /** Identifier holding all the info that uniquely identifies a distribution.
+    **/
+    std::string m_process_name {};  // Name of process
+    std::string m_distr_name {};    // Name of distribution
+    std::string m_pol_config {};    // Name of polarisation setting
+    double      m_energy {};        // Center of mass energy
+  };
+  
+}
+}
+
+#endif 

--- a/source/prew/include/Data/DistrUtils.h
+++ b/source/prew/include/Data/DistrUtils.h
@@ -1,0 +1,35 @@
+#ifndef LIB_DISTRUTILS_H
+#define LIB_DISTRUTILS_H 1
+
+#include <string>
+#include <vector>
+
+namespace PREW {
+namespace Data {
+
+namespace DistrUtils {
+  /** Functions that can help with the various distribution types in the Data
+      namespace and that are not specific to one distribution type.
+  **/
+  
+  template<class T>
+  std::vector<T> subvec_energy_and_name(const std::vector<T>& vec, 
+                                        int energy, 
+                                        std::string distr_name);
+  
+  template<class T>
+  std::vector<T> subvec_energy(const std::vector<T>& vec, int energy);
+  template<class T>
+  std::vector<T> subvec_pol(const std::vector<T>& vec, 
+                            const std::string& pol_config);
+  
+  template<class T>
+  T element_pol(const std::vector<T>& vec, const std::string& pol_config);
+}
+  
+}
+}
+
+#include <Data/DistrUtils.tpp>
+
+#endif 

--- a/source/prew/include/Data/DistrUtils.tpp
+++ b/source/prew/include/Data/DistrUtils.tpp
@@ -1,0 +1,112 @@
+#ifndef LIB_DISTRUTILS_TPP
+#define LIB_DISTRUTILS_TPP 1
+
+#include <CppUtils/Vec.h>
+#include <Data/DistrUtils.h>
+
+#include "spdlog/spdlog.h"
+
+#include <algorithm>
+
+namespace PREW {
+namespace Data {
+
+//------------------------------------------------------------------------------
+
+template<class T>
+std::vector<T> DistrUtils::subvec_energy_and_name(
+  const std::vector<T>& vec, 
+  int energy, 
+  std::string distr_name
+) {
+  /** Find sub-vector of vector vec in which only distributions are contained 
+      whose info contain the given energy and distr_name.
+  **/
+  
+  // Lambda comparison checking energy and name match for single distribution
+  auto info_comparison = [energy, distr_name](const T& distr) { 
+                          return (distr.m_info.m_energy == energy) &&
+                                 (distr.m_info.m_distr_name == distr_name);
+                          };
+  
+  // Return all distributions where energy and name match
+  return CppUtils::Vec::subvec_by_condition( vec, info_comparison ); 
+}
+
+//------------------------------------------------------------------------------
+
+template<class T>
+std::vector<T> DistrUtils::subvec_energy(
+  const std::vector<T>& vec, 
+  int energy
+) {
+  /** Find sub-vector of vector vec in which only distributions are contained 
+      whose info contain the given energy.
+  **/
+  
+  // Lambda comparison checking energy match for single distribution
+  auto info_comparison =  [energy](const T& distr) { 
+                            return (distr.m_info.m_energy == energy);
+                          };
+  
+  // Return all distributions where energy match
+  return CppUtils::Vec::subvec_by_condition( vec, info_comparison ); 
+}
+
+//------------------------------------------------------------------------------
+
+template<class T>
+std::vector<T> DistrUtils::subvec_pol( 
+  const std::vector<T>& vec, 
+  const std::string& pol_config
+) {
+  /** Find polarisation-specific sub-vector in distribution vector vec.
+  **/
+  
+  // Lambda comparison checking polarisation match for single distribution
+  auto info_comparison = [pol_config](const T& distr) { 
+                            return (distr.m_info.m_pol_config == pol_config);
+                          };
+  
+  // Return all matching distributions
+  return CppUtils::Vec::subvec_by_condition( vec, info_comparison );
+}
+
+//------------------------------------------------------------------------------
+
+template<class T>
+T DistrUtils::element_pol( 
+  const std::vector<T>& vec, 
+  const std::string& pol_config
+) {
+  /** Find polarisation-specific element in distribution vector vec.
+      Includes check that exactly one such element exists.
+  **/
+  T output_element {};
+  
+  // Get all elements that fulfill polarisation condition
+  auto all_pol_elements = subvec_pol( vec, pol_config );
+  
+  // Check for how many are found
+  if ( all_pol_elements.size() == 0 ) {
+    spdlog::warn("Vector doesn't have element of pol. {}", pol_config);
+  } else {
+    output_element = all_pol_elements.at(0);
+  }
+  
+  if ( all_pol_elements.size() > 1 ) {
+    spdlog::warn(
+      "Vector has more than one element of pol. {} , returning first", 
+      pol_config
+    );
+  }
+  
+  return output_element;
+}
+
+//------------------------------------------------------------------------------
+
+}
+}
+
+#endif

--- a/source/prew/include/Data/FnctLink.h
+++ b/source/prew/include/Data/FnctLink.h
@@ -1,0 +1,24 @@
+#ifndef LIB_FNCTLINK_H
+#define LIB_FNCTLINK_H 1
+
+#include <string>
+#include <vector>
+
+namespace PREW {
+namespace Data {
+  
+  struct FnctLink {
+    /** Class that stores the names of parameters and coefficients 
+        which are supposed to be used when using the given function.
+    **/
+    
+    std::string m_fnct_name {};
+    std::vector<std::string> m_pars {};
+    std::vector<std::string> m_coefs {};
+  };
+  
+  using FnctLinkVec = std::vector<FnctLink>;
+}
+}
+
+#endif

--- a/source/prew/include/Data/PolLink.h
+++ b/source/prew/include/Data/PolLink.h
@@ -1,0 +1,25 @@
+#ifndef LIB_POLLINK_H
+#define LIB_POLLINK_H 1
+
+#include <CppUtils/Map.h>
+
+namespace PREW {
+namespace Data {
+
+  struct PolLink {
+    /** Class that stores which polarisation configuration couples which 
+        individual beam polarisations together.
+    **/
+    
+    int m_energy {}; // This depends on the energy!
+    
+    // Map from polarisation setup to individual beam polarisation names
+    // => Rule: First electron polarisation, second positron polarisation
+    CppUtils::Map::StrToStrPairMap m_config_pol_links {};
+  };
+
+  using PolLinkVec = std::vector<PolLink>;
+}
+}
+
+#endif

--- a/source/prew/include/Data/PredDistr.h
+++ b/source/prew/include/Data/PredDistr.h
@@ -1,0 +1,28 @@
+#ifndef LIBRARY_PREDDISTR_H
+#define LIBRARY_PREDDISTR_H
+
+#include <Data/DistrInfo.h>
+
+#include <vector>
+
+namespace PREW {
+namespace Data {
+  
+  struct PredDistr {
+    /** Class holding a predictions for differential distribution of a process
+        for one chirality.
+    **/
+    
+    DistrInfo m_info {}; // Info which identifies this distribution
+    
+    // Values of observables at bin center
+    CppUtils::Vec::Matrix2D<double> m_bin_centers {}; 
+    std::vector<double> m_distribution {}; // Predicted distribution
+  };
+  
+  typedef std::vector<PredDistr> PredDistrVec;
+  
+} 
+}
+
+#endif

--- a/source/prew/include/Data/PredDistr.h
+++ b/source/prew/include/Data/PredDistr.h
@@ -18,7 +18,8 @@ namespace Data {
     
     // Values of observables at bin center
     CppUtils::Vec::Matrix2D<double> m_bin_centers {}; 
-    std::vector<double> m_distribution {}; // Predicted distribution
+    std::vector<double> m_sig_distr {}; // Predicted signal distribution
+    std::vector<double> m_bkg_distr {}; // Predicted background distribution
   };
   
   typedef std::vector<PredDistr> PredDistrVec;

--- a/source/prew/include/Data/PredDistr.h
+++ b/source/prew/include/Data/PredDistr.h
@@ -10,8 +10,8 @@ namespace PREW {
 namespace Data {
   
   struct PredDistr {
-    /** Class holding a predictions for differential distribution of a process
-        for one chirality.
+    /** Class holding a predictions for differential distribution for one 
+        chirality.
     **/
     
     DistrInfo m_info {}; // Info which identifies this distribution

--- a/source/prew/include/Data/PredDistr.h
+++ b/source/prew/include/Data/PredDistr.h
@@ -1,6 +1,7 @@
 #ifndef LIBRARY_PREDDISTR_H
 #define LIBRARY_PREDDISTR_H
 
+#include <CppUtils/Vec.h>
 #include <Data/DistrInfo.h>
 
 #include <vector>

--- a/source/prew/include/Data/PredLink.h
+++ b/source/prew/include/Data/PredLink.h
@@ -1,0 +1,28 @@
+#ifndef LIB_PREDLINK_H
+#define LIB_PREDLINK_H 1
+
+#include <Data/DistrInfo.h>
+#include <Data/FnctLink.h>
+
+#include <vector>
+
+namespace PREW {
+namespace Data {
+  
+  struct PredLink {
+    /** Class to store how the functions for a given distribution (identified by
+        the info) are supposed to be linked to their parameters.
+        => For both signal and background of the distribution.
+    **/
+
+    DistrInfo m_info {};
+    FnctLinkVec m_fncts_links_sig {}; // Modification of signal Xsection
+    FnctLinkVec m_fncts_links_bkg {}; // Modification of bkg Xsection 
+    
+  };
+  
+  using PredLinkVec = std::vector<PredLink>;
+}
+}
+
+#endif

--- a/source/prew/include/Fit/ChiSqMinimizer.h
+++ b/source/prew/include/Fit/ChiSqMinimizer.h
@@ -35,13 +35,13 @@ namespace Fit {
   
   public:
     // Constructors
-    ChiSqMinimizer(FitContainer * container, MinuitFactory &factory);
+    ChiSqMinimizer(FitContainer * container, const MinuitFactory &factory);
     
     void minimize();
     
     // Get function
     double get_chisq() const;
-    FitResult get_result() const;
+    const FitResult& get_result() const;
   };
   
 }

--- a/source/prew/include/Fit/FitBin.h
+++ b/source/prew/include/Fit/FitBin.h
@@ -2,6 +2,7 @@
 #define LIB_FITBIN_H 1
 
 #include <functional>
+#include <vector>
 
 namespace PREW {
 namespace Fit {
@@ -18,7 +19,7 @@ namespace Fit {
     
     public:
       // Constructors
-      FitBin(double val_mst, double val_unc, std::function<double()> prd_fct=NULL);
+      FitBin(double val_mst=0, double val_unc=0, std::function<double()> prd_fct=NULL);
       
       double get_val_mst() const; // Get measured value
       double get_val_unc() const; // Get measurement uncertainty

--- a/source/prew/include/Fit/FitBin.h
+++ b/source/prew/include/Fit/FitBin.h
@@ -8,7 +8,8 @@ namespace PREW {
 namespace Fit {
   
   class FitBin {
-    /** Class describing the prediction for a bin depending on a set of fit parameters.
+    /** Class describing the prediction for a bin depending on a set of fit 
+        parameters.
     **/
     
     double m_val_mst {}; // measured value
@@ -19,7 +20,13 @@ namespace Fit {
     
     public:
       // Constructors
-      FitBin(double val_mst=0, double val_unc=0, std::function<double()> prd_fct=NULL);
+      FitBin(
+        double val_mst=0, 
+        double val_unc=0, 
+        std::function<double()> prd_fct=NULL
+      );
+      
+      void set_prd_fct(std::function<double()> prd_fct); // Set prediction fct.
       
       double get_val_mst() const; // Get measured value
       double get_val_unc() const; // Get measurement uncertainty

--- a/source/prew/include/Fit/FitContainer.h
+++ b/source/prew/include/Fit/FitContainer.h
@@ -1,27 +1,23 @@
 #ifndef LIB_FITCONTAINER_H
 #define LIB_FITCONTAINER_H 1
 
-#include <Fit/FitPar.h>
 #include <Fit/FitBin.h>
+#include <Fit/FitPar.h>
 
 #include <vector>
 
 namespace PREW {
 namespace Fit {
   
-  // TODO => Still useful to store the everything that is used for ONE SPECIFIC FIT!
-  // -> Each fit should have own container which is handed to ChiSqMinimizer
-
   struct FitContainer {
     /** Class to hold complete set of bins and corresponding fit parameters that
         are to be used in the chi-squared minimization.
     **/
   
-    ParVec m_fit_pars {}; // Fit parameters 
-    BinVec m_fit_bins {}; // Bins (whose prediction is connected to the parameters)
-    
-    // public:
-      
+    // Fit parameters 
+    ParVec m_fit_pars {}; 
+    // Bins (whose prediction is connected to the parameters and coefficients)
+    BinVec m_fit_bins {}; 
   };
 
 }

--- a/source/prew/include/Fit/FitPar.h
+++ b/source/prew/include/Fit/FitPar.h
@@ -39,6 +39,7 @@ namespace Fit {
       
       // Operators
       bool operator==(const FitPar& fit_par) const;
+      FitPar& operator=(const FitPar& other) = default;
   };
   
   typedef std::vector<FitPar> ParVec;

--- a/source/prew/include/Fit/ParConstrGauss.h
+++ b/source/prew/include/Fit/ParConstrGauss.h
@@ -17,6 +17,13 @@ namespace Fit {
       ParConstrGauss(double val, double unc);
       
       double calc_chisq(double par_val) const;
+      
+      double get_val() const;
+      double get_unc() const;
+      
+      // Operators
+      bool operator==(const ParConstrGauss& other) const;
+      ParConstrGauss& operator=(const ParConstrGauss& other) = default;
   };
   
 }

--- a/source/prew/include/Fncts/FnctMap.h
+++ b/source/prew/include/Fncts/FnctMap.h
@@ -1,6 +1,7 @@
 #ifndef LIB_FNCTMAP_H
 #define LIB_FNCTMAP_H 1
 
+#include <Fncts/Physics.h>
 #include <Fncts/Polynomial.h>
 #include <Fncts/Statistic.h>
 #include <CppUtils/Fnct.h>
@@ -18,7 +19,8 @@ namespace Fncts {
   // All parameterisation functions must have their own unique ID!
   static const FnctMap prew_fnct_map = {
     {"Quadratic1DPolynomial", Polynomial::quadratic_1D},
-    {"Gaussian1D", Statistic::gaussian_1D}  
+    {"Gaussian1D", Statistic::gaussian_1D},
+    {"PolarisationFactor", Physics::polarisation_factor}
   };
 
   

--- a/source/prew/include/Fncts/FnctMap.h
+++ b/source/prew/include/Fncts/FnctMap.h
@@ -1,0 +1,28 @@
+#ifndef LIB_FNCTMAP_H
+#define LIB_FNCTMAP_H 1
+
+#include <Fncts/Polynomial.h>
+#include <Fncts/Statistic.h>
+#include <CppUtils/Fnct.h>
+
+#include <map>
+#include <string>
+
+namespace PREW {
+namespace Fncts {
+  // Kind of map pointing from a string (function-ID) to a function 
+  // which has three input parameter vectors: coordinate,parameters,coefficients
+  using FnctMap = std::map<std::string, CppUtils::Fnct::ParametrisationFnct>;
+        
+  // This fixes the association of a funtion-ID string to an actual function.
+  // All parameterisation functions must have their own unique ID!
+  static const FnctMap prew_fnct_map = {
+    {"Quadratic1DPolynomial", Polynomial::quadratic_1D},
+    {"Gaussian1D", Statistic::gaussian_1D}  
+  };
+
+  
+}
+}
+
+#endif

--- a/source/prew/include/Fncts/Physics.h
+++ b/source/prew/include/Fncts/Physics.h
@@ -1,0 +1,25 @@
+#ifndef LIB_PHYSICS_H
+#define LIB_PHYSICS_H 1
+
+#include <vector>
+
+namespace PREW {
+namespace Fncts {
+  
+namespace Physics {
+  /** Namespace for parametrisation functions from statistics.
+      Must all follow structure:
+        double fnct_name (const std::vector<double>   &x,
+                          const std::vector<double>   &c,
+                          const std::vector<double*>  &p);
+  **/
+  
+  double polarisation_factor (const std::vector<double>   &x,
+                              const std::vector<double>   &c,
+                              const std::vector<double*>  &p);
+}
+  
+}
+}
+
+#endif

--- a/source/prew/include/Fncts/Polynomial.h
+++ b/source/prew/include/Fncts/Polynomial.h
@@ -1,0 +1,26 @@
+#ifndef LIB_POLYNOMIAL_H
+#define LIB_POLYNOMIAL_H 1
+
+#include <vector>
+
+namespace PREW {
+namespace Fncts {
+  
+namespace Polynomial {
+  /** Namespace for polynomial parametrisation functions.
+      Must all follow structure:
+        double fnct_name (const std::vector<double>   &x,
+                          const std::vector<double>   &c,
+                          const std::vector<double*>  &p);
+  **/
+  
+  double quadratic_1D ( const std::vector<double>   &x,
+                        const std::vector<double>   &c,
+                        const std::vector<double*>  &p);
+                        
+}
+  
+}
+}
+
+#endif

--- a/source/prew/include/Fncts/Statistic.h
+++ b/source/prew/include/Fncts/Statistic.h
@@ -1,0 +1,25 @@
+#ifndef LIB_STATISTIC_H
+#define LIB_STATISTIC_H 1
+
+#include <vector>
+
+namespace PREW {
+namespace Fncts {
+  
+namespace Statistic {
+  /** Namespace for parametrisation functions from statistics.
+      Must all follow structure:
+        double fnct_name (const std::vector<double>   &x,
+                          const std::vector<double>   &c,
+                          const std::vector<double*>  &p);
+  **/
+  
+  double gaussian_1D (const std::vector<double>   &x,
+                      const std::vector<double>   &c,
+                      const std::vector<double*>  &p);
+}
+  
+}
+}
+
+#endif

--- a/source/prew/include/GlobalVar/Chiral.h
+++ b/source/prew/include/GlobalVar/Chiral.h
@@ -1,0 +1,24 @@
+#ifndef LIBRARY_CHIRAL_H
+#define LIBRARY_CHIRAL_H 1
+
+#include <string>
+
+namespace PREW {
+namespace GlobalVar {
+/** Careful with this namespace, only for static const variables!
+**/
+    
+  namespace Chiral {
+    /** Common strings to mark generator level chiral distributions.
+    **/
+    
+    static const std::string eLpR = "PrEW-internal-GenLevel-ElectronL-PositronR";
+    static const std::string eRpL = "PrEW-internal-GenLevel-ElectronR-PositronL";
+    static const std::string eLpL = "PrEW-internal-GenLevel-ElectronL-PositronL";
+    static const std::string eRpR = "PrEW-internal-GenLevel-ElectronR-PositronR";
+  }
+    
+}
+}
+
+#endif

--- a/source/prew/include/Input/DataReader.h
+++ b/source/prew/include/Input/DataReader.h
@@ -1,7 +1,7 @@
 #ifndef LIBRARY_DATAREADER_H
 #define LIBRARY_DATAREADER_H 1
 
-#include <Data/Distr1D.h>
+#include <Data/DiffDistr.h>
 #include <Input/InputInfo.h>
 #include <Input/Reading.h>
 
@@ -16,14 +16,14 @@ namespace Input {
     
     InputInfo *m_input_info {};
     std::string m_input_style {};
-    Data::Distr1DVec m_distributions {};
+    Data::DiffDistrVec m_distributions {};
     
     public:
       // Constructors
       DataReader(InputInfo *input_info, std::string input_style);
       
       void read_file();
-      Data::Distr1DVec get_distributions() const;
+      Data::DiffDistrVec get_distributions() const;
   };
   
 }

--- a/source/prew/include/Input/DataReader.h
+++ b/source/prew/include/Input/DataReader.h
@@ -21,14 +21,13 @@ namespace Input {
     **/
     
     InputInfo *m_input_info {};
-    std::string m_input_style {};
     Data::DiffDistrVec m_meas_distrs {};
     Data::PredDistrVec m_pred_distrs {};
     Data::CoefDistrVec m_coef_distrs {};
     
     public:
       // Constructors
-      DataReader(InputInfo *input_info, std::string input_style);
+      DataReader(InputInfo *input_info);
       
       void read_file();
       Data::DiffDistrVec get_meas_distrs() const;

--- a/source/prew/include/Input/DataReader.h
+++ b/source/prew/include/Input/DataReader.h
@@ -2,6 +2,7 @@
 #define LIBRARY_DATAREADER_H 1
 
 #include <Data/DiffDistr.h>
+#include <Data/PredDistr.h>
 #include <Input/InputInfo.h>
 #include <Input/Reading.h>
 
@@ -16,14 +17,16 @@ namespace Input {
     
     InputInfo *m_input_info {};
     std::string m_input_style {};
-    Data::DiffDistrVec m_distributions {};
+    Data::DiffDistrVec m_meas_distrs {};
+    Data::PredDistrVec m_pred_distrs {};
     
     public:
       // Constructors
       DataReader(InputInfo *input_info, std::string input_style);
       
       void read_file();
-      Data::DiffDistrVec get_distributions() const;
+      Data::DiffDistrVec get_meas_distrs() const;
+      Data::PredDistrVec get_pred_distrs() const;
   };
   
 }

--- a/source/prew/include/Input/DataReader.h
+++ b/source/prew/include/Input/DataReader.h
@@ -30,9 +30,9 @@ namespace Input {
       DataReader(InputInfo *input_info);
       
       void read_file();
-      Data::DiffDistrVec get_meas_distrs() const;
-      Data::PredDistrVec get_pred_distrs() const;
-      Data::CoefDistrVec get_coef_distrs() const;
+      const Data::DiffDistrVec& get_meas_distrs() const;
+      const Data::PredDistrVec& get_pred_distrs() const;
+      const Data::CoefDistrVec& get_coef_distrs() const;
   };
   
 }

--- a/source/prew/include/Input/DataReader.h
+++ b/source/prew/include/Input/DataReader.h
@@ -12,13 +12,19 @@ namespace Input {
   
   class DataReader {
     /** General data reader class to get data from an input file.
-        -> Only does general checks, e.g. if file exists.
+        Three types of data can be of relevance for a fit and may be extracted
+        depending on the file type:
+        - Measured differential distributions (in number of events!)
+          with uncorrelated uncertainties
+        - Predicted chiral distributions
+        - Coefficients of parameterisation of the prediction
     **/
     
     InputInfo *m_input_info {};
     std::string m_input_style {};
     Data::DiffDistrVec m_meas_distrs {};
     Data::PredDistrVec m_pred_distrs {};
+    Data::CoefDistrVec m_coef_distrs {};
     
     public:
       // Constructors
@@ -27,6 +33,7 @@ namespace Input {
       void read_file();
       Data::DiffDistrVec get_meas_distrs() const;
       Data::PredDistrVec get_pred_distrs() const;
+      Data::CoefDistrVec get_coef_distrs() const;
   };
   
 }

--- a/source/prew/include/Input/InputInfo.h
+++ b/source/prew/include/Input/InputInfo.h
@@ -11,7 +11,8 @@ namespace Input {
         multiple InputInfo.
     **/
     
-    std::string m_file_path {}; // Input file path, must be in all input infos
+    std::string m_file_path {};   // Input file path, must be in all input infos
+    std::string m_input_style {}; // Type of input file
   };
   
 }

--- a/source/prew/include/Input/Reading.h
+++ b/source/prew/include/Input/Reading.h
@@ -1,6 +1,7 @@
 #ifndef LIBRARY_READING_H
 #define LIBRARY_READING_H 1
 
+#include <Data/CoefDistr.h>
 #include <Data/PredDistr.h>
 #include <Input/InputInfo.h>
 
@@ -13,7 +14,9 @@ namespace Reading {
   
   //----------------------------------------------------------------------------
 
-  Data::PredDistrVec read_RK_file(InputInfo *input_info);
+  void read_RK_file(const InputInfo *input_info, 
+                    Data::PredDistrVec *pred_distrs, 
+                    Data::CoefDistrVec *coef_distrs);
 
   //----------------------------------------------------------------------------
   

--- a/source/prew/include/Input/Reading.h
+++ b/source/prew/include/Input/Reading.h
@@ -1,7 +1,7 @@
 #ifndef LIBRARY_READING_H
 #define LIBRARY_READING_H 1
 
-#include <Data/DiffDistr.h>
+#include <Data/PredDistr.h>
 #include <Input/InputInfo.h>
 
 namespace PREW {
@@ -13,7 +13,7 @@ namespace Reading {
   
   //----------------------------------------------------------------------------
 
-  Data::DiffDistrVec read_RK_file(InputInfo *input_info);
+  Data::PredDistrVec read_RK_file(InputInfo *input_info);
 
   //----------------------------------------------------------------------------
   

--- a/source/prew/include/Input/Reading.h
+++ b/source/prew/include/Input/Reading.h
@@ -1,7 +1,7 @@
 #ifndef LIBRARY_READING_H
 #define LIBRARY_READING_H 1
 
-#include <Data/Distr1D.h>
+#include <Data/DiffDistr.h>
 #include <Input/InputInfo.h>
 
 namespace PREW {
@@ -13,7 +13,7 @@ namespace Reading {
   
   //----------------------------------------------------------------------------
 
-  Data::Distr1DVec read_RK_file(InputInfo *input_info);
+  Data::DiffDistrVec read_RK_file(InputInfo *input_info);
 
   //----------------------------------------------------------------------------
   

--- a/source/prew/include/ToyMeas/ToyGenerator.h
+++ b/source/prew/include/ToyMeas/ToyGenerator.h
@@ -1,0 +1,51 @@
+#ifndef LIB_TOYGENERATOR_H
+#define LIB_TOYGENERATOR_H 1
+
+#include <Connect/DataConnector.h>
+#include <Data/DiffDistr.h>
+#include <Fit/FitPar.h>
+
+#include <functional>
+
+namespace PREW { 
+namespace ToyMeas {
+
+  class ToyGenerator {
+    /** Class that can create a toy measurements from generator level 
+        distributions by fluctuating the expected number of events within 
+        their poissonian uncertainty.
+    **/
+    
+
+    // TODO 
+    // Similar to DataToFit
+    // Takes same input expect: No measurement & no output pointer
+    // => Creates its own internal FitContainer (with correctly connected FitBin predictions)
+    //      -> NOPE, needs to use combination of DiffDistrVec and ParVec instead because connection to DistrInfo still needed
+    // => Has function that creates vector DiffDistrVec in which predictions of FitBins are varied with Poissonian
+    // => Has function that can manipulate one of the FitPar values (by name of FitPar)
+    // TODO
+    
+    // TODO
+    // The function to create a toy distribution must take energy as input argument!
+    // TODO
+    
+    // Provided as input
+    Connect::DataConnector  m_connector {};
+    Fit::ParVec             m_pars {};
+    
+    // Created by ToyGenerator: diff. distrs. from predictions
+    Data::DiffDistrVec      m_diff_distrs {};
+    
+    public:
+      ToyGenerator(
+        const Connect::DataConnector & connector,
+        const Fit::ParVec & pars
+      );
+      
+      Data::DiffDistrVec get_expected_distrs ( int energy ) const;
+  };
+}
+}
+
+#endif

--- a/source/prew/src/Connect/DataConnector.cpp
+++ b/source/prew/src/Connect/DataConnector.cpp
@@ -1,0 +1,309 @@
+#include <Connect/DataConnector.h>
+#include <Connect/Linker.h>
+#include <Connect/LinkHelp.h>
+#include <Data/DistrUtils.h>
+#include <GlobalVar/Chiral.h>
+
+#include "spdlog/spdlog.h"
+
+#include <exception>
+#include <string>
+
+namespace PREW {
+namespace Connect {
+
+//------------------------------------------------------------------------------
+// Constructors
+
+DataConnector::DataConnector (
+  Data::PredDistrVec pred_distrs,
+  Data::CoefDistrVec coef_distrs,
+  Data::PredLinkVec  pred_links ,
+  Data::PolLinkVec   pol_links  
+) : 
+  m_pred_distrs(pred_distrs), 
+  m_coef_distrs(coef_distrs), 
+  m_pred_links(pred_links), 
+  m_pol_links(pol_links)
+{
+  // Check that necessary inputs are there
+  if (m_pred_distrs.size() == 0) {
+    throw std::invalid_argument("DataConnector needs predicted distributions!");
+  }
+  if (m_pol_links.size() == 0) {
+    throw std::invalid_argument("DataConnector needs polarisation links!");
+  }
+  
+  // Check if optional inputs are there
+  if (m_coef_distrs.size() == 0) {
+    spdlog::debug("No coefficients supplied to DataConnector.");
+  }
+  if (m_pred_links.size() == 0) {
+    spdlog::debug("No prediction links supplied to DataConnector.");
+  }
+}
+
+//------------------------------------------------------------------------------
+// Read functions
+
+const Data::PredDistrVec& DataConnector::get_pred_distrs() const { 
+  return m_pred_distrs; 
+}
+const Data::CoefDistrVec& DataConnector::get_coef_distrs() const { 
+  return m_coef_distrs; 
+}
+const Data::PredLinkVec&  DataConnector::get_pred_links()  const { 
+  return m_pred_links; 
+}
+const Data::PolLinkVec&   DataConnector::get_pol_links()   const { 
+  return m_pol_links; 
+}
+
+//------------------------------------------------------------------------------
+// Core functionality
+
+void DataConnector::fill_bins(
+  const Data::DiffDistr & diff_distr,
+  Fit::ParVec *pars,
+  Fit::BinVec *bins
+) const {
+  /** Set bin prediction functions for all bins of the distribution.
+      Predictions will be correctly connected to the given input parameters.
+      
+      A full prediction for a single bin is calculated as:
+        f_pol,1 * ... * f_pol,n *
+        ( (1-Pe-)*)(1+Pe+)/4 * f_LR,1 * ... * f_LR,n * pred_LR +
+          ... +
+          (1+Pe-)*)(1+Pe+)/4 * f_RR,1 * ... * f_LR,n * pred_RR
+        )
+        {Calculated for signal and background separately and then added up.}
+      Where:
+        f_pol,i : factor functions applied to the prediction for a given 
+                  polarisation configuration
+        f_LR/LL/...,i : factor functions applied to the prediction for a given 
+                        incoming particle helicity 
+        Pe- : electron polarisation
+        Pe+ : positron polarisation
+  **/
+  
+  // Information of the given distribution
+  std::string distr_name = diff_distr.m_info.m_distr_name;
+  std::string pol_config = diff_distr.m_info.m_pol_config;
+  int energy             = diff_distr.m_info.m_energy;
+  
+  CppUtils::Vec::Matrix2D<double> bin_centers = diff_distr.m_bin_centers;
+  
+  // Find polarisation link for this energy
+  auto energy_condition = 
+    [energy](const Data::PolLink& link) {return link.m_energy==energy;};
+  Data::PolLink pol_link = 
+    CppUtils::Vec::element_by_condition( m_pol_links, energy_condition );
+
+  // Individual beam polarisations
+  auto pol_pair = pol_link.m_config_pol_links.at(pol_config);
+
+  // Find corresponding predicted distributions, links and coefficients
+  Data::PredDistrVec predictions  = 
+    Data::DistrUtils::subvec_energy_and_name(m_pred_distrs, energy, distr_name);
+  Data::CoefDistrVec coefficients = 
+    Data::DistrUtils::subvec_energy_and_name(m_coef_distrs, energy, distr_name);
+  Data::PredLinkVec links         = 
+    Data::DistrUtils::subvec_energy_and_name(m_pred_links, energy, distr_name);
+
+  // --- Get chiral predictions, links and coefficients ------------------------
+  auto pred_LR = Data::DistrUtils::element_pol( predictions, 
+                                                GlobalVar::Chiral::eLpR);
+  auto pred_RL = Data::DistrUtils::element_pol( predictions, 
+                                                GlobalVar::Chiral::eRpL);
+  auto pred_LL = Data::DistrUtils::element_pol( predictions, 
+                                                GlobalVar::Chiral::eLpL);
+  auto pred_RR = Data::DistrUtils::element_pol( predictions, 
+                                                GlobalVar::Chiral::eRpR);
+
+  auto links_LR = Data::DistrUtils::element_pol(links, GlobalVar::Chiral::eLpR);
+  auto links_RL = Data::DistrUtils::element_pol(links, GlobalVar::Chiral::eRpL);
+  auto links_LL = Data::DistrUtils::element_pol(links, GlobalVar::Chiral::eLpL);
+  auto links_RR = Data::DistrUtils::element_pol(links, GlobalVar::Chiral::eRpR);
+
+  auto coefs_LR = Data::DistrUtils::subvec_pol( coefficients, 
+                                                GlobalVar::Chiral::eLpR);
+  auto coefs_RL = Data::DistrUtils::subvec_pol( coefficients, 
+                                                GlobalVar::Chiral::eRpL);
+  auto coefs_LL = Data::DistrUtils::subvec_pol( coefficients, 
+                                                GlobalVar::Chiral::eLpL);
+  auto coefs_RR = Data::DistrUtils::subvec_pol( coefficients, 
+                                                GlobalVar::Chiral::eRpR);
+  // ---------------------------------------------------------------------------
+
+  // --- Get linkers for chiral alpha functions ------- ------------------------
+  Connect::Linker linker_sig_LR = 
+    Connect::Linker(links_LR.m_fncts_links_sig, bin_centers, coefs_LR);
+  Connect::Linker linker_bkg_LR = 
+    Connect::Linker(links_LR.m_fncts_links_bkg, bin_centers, coefs_LR);
+
+  Connect::Linker linker_sig_RL = 
+    Connect::Linker(links_RL.m_fncts_links_sig, bin_centers, coefs_RL);
+  Connect::Linker linker_bkg_RL = 
+    Connect::Linker(links_RL.m_fncts_links_bkg, bin_centers, coefs_RL);
+
+  Connect::Linker linker_sig_LL = 
+    Connect::Linker(links_LL.m_fncts_links_sig, bin_centers, coefs_LL);
+  Connect::Linker linker_bkg_LL = 
+    Connect::Linker(links_LL.m_fncts_links_bkg, bin_centers, coefs_LL);
+
+  Connect::Linker linker_sig_RR = 
+    Connect::Linker(links_RR.m_fncts_links_sig, bin_centers, coefs_RR);
+  Connect::Linker linker_bkg_RR = 
+    Connect::Linker(links_RR.m_fncts_links_bkg, bin_centers, coefs_RR);
+  // ---------------------------------------------------------------------------
+
+  // --- Get linkers for polarised alpha functions -----------------------------
+  auto links_pol = Data::DistrUtils::element_pol(links, pol_config);
+  auto coefs_pol = Data::DistrUtils::subvec_pol(coefficients, pol_config);
+
+  Connect::Linker linker_sig_pol = 
+    Connect::Linker(links_pol.m_fncts_links_sig, bin_centers, coefs_pol);
+  Connect::Linker linker_bkg_pol = 
+    Connect::Linker(links_pol.m_fncts_links_bkg, bin_centers, coefs_pol);
+  // ---------------------------------------------------------------------------
+
+  // --- Get polarisation factor alpha functions -------------------------------
+  auto pol_factor_LR = 
+    LinkHelp::get_polfactor_lambda(GlobalVar::Chiral::eLpR, pol_pair, pars);
+  auto pol_factor_RL = 
+    LinkHelp::get_polfactor_lambda(GlobalVar::Chiral::eRpL, pol_pair, pars);
+  auto pol_factor_LL = 
+    LinkHelp::get_polfactor_lambda(GlobalVar::Chiral::eLpL, pol_pair, pars);
+  auto pol_factor_RR = 
+    LinkHelp::get_polfactor_lambda(GlobalVar::Chiral::eRpR, pol_pair, pars);
+  // ---------------------------------------------------------------------------
+
+  // Set the prediction of each distribution
+  for ( size_t bin=0; bin<bin_centers.size(); bin++ ) {
+    // -------------------- Get chiral signal prediction -----------------------
+    double sigma_sig_LR = pred_LR.m_sig_distr[bin];
+    double sigma_sig_RL = pred_RL.m_sig_distr[bin];
+    double sigma_sig_LL = pred_LL.m_sig_distr[bin];
+    double sigma_sig_RR = pred_RR.m_sig_distr[bin];
+
+    auto alphas_sig_LR = linker_sig_LR.get_all_bonded_fncts_at_bin(bin, pars);
+    auto alphas_sig_RL = linker_sig_RL.get_all_bonded_fncts_at_bin(bin, pars);
+    auto alphas_sig_LL = linker_sig_LL.get_all_bonded_fncts_at_bin(bin, pars);
+    auto alphas_sig_RR = linker_sig_RR.get_all_bonded_fncts_at_bin(bin, pars);
+
+    auto sigma_sig_LR_mod =
+        LinkHelp::get_modified_sigma(sigma_sig_LR, alphas_sig_LR);
+    auto sigma_sig_RL_mod =
+        LinkHelp::get_modified_sigma(sigma_sig_RL, alphas_sig_RL);
+    auto sigma_sig_LL_mod =
+        LinkHelp::get_modified_sigma(sigma_sig_LL, alphas_sig_LL);
+    auto sigma_sig_RR_mod =
+        LinkHelp::get_modified_sigma(sigma_sig_RR, alphas_sig_RR);
+    // -------------------------------------------------------------------------
+
+    // -------------------- Get chiral background prediction -------------------
+    double sigma_bkg_LR = pred_LR.m_bkg_distr[bin];
+    double sigma_bkg_RL = pred_RL.m_bkg_distr[bin];
+    double sigma_bkg_LL = pred_LL.m_bkg_distr[bin];
+    double sigma_bkg_RR = pred_RR.m_bkg_distr[bin];
+
+    auto alphas_bkg_LR = linker_bkg_LR.get_all_bonded_fncts_at_bin(bin, pars);
+    auto alphas_bkg_RL = linker_bkg_RL.get_all_bonded_fncts_at_bin(bin, pars);
+    auto alphas_bkg_LL = linker_bkg_LL.get_all_bonded_fncts_at_bin(bin, pars);
+    auto alphas_bkg_RR = linker_bkg_RR.get_all_bonded_fncts_at_bin(bin, pars);
+
+    auto sigma_bkg_LR_mod =
+        LinkHelp::get_modified_sigma(sigma_bkg_LR, alphas_bkg_LR);
+    auto sigma_bkg_RL_mod =
+        LinkHelp::get_modified_sigma(sigma_bkg_RL, alphas_bkg_RL);
+    auto sigma_bkg_LL_mod =
+        LinkHelp::get_modified_sigma(sigma_bkg_LL, alphas_bkg_LL);
+    auto sigma_bkg_RR_mod =
+        LinkHelp::get_modified_sigma(sigma_bkg_RR, alphas_bkg_RR);
+    // -------------------------------------------------------------------------
+
+    // -------------------- Get polarised signal prediction --------------------
+    auto alphas_sig_pol = linker_sig_pol.get_all_bonded_fncts_at_bin(bin, pars);
+
+    // No longer sigma because includes lumi => #Events
+    auto pred_sig_pol =
+      [ sigma_sig_LR_mod, pol_factor_LR,
+        sigma_sig_RL_mod, pol_factor_RL,
+        sigma_sig_LL_mod, pol_factor_LL,
+        sigma_sig_RR_mod, pol_factor_RR,
+        alphas_sig_pol
+      ] () {
+        double sigma_mod =  pol_factor_LR() * sigma_sig_LR_mod() +
+                            pol_factor_RL() * sigma_sig_RL_mod() +
+                            pol_factor_LL() * sigma_sig_LL_mod() +
+                            pol_factor_RR() * sigma_sig_RR_mod();
+        for (const auto & alpha: alphas_sig_pol) {sigma_mod *= alpha();}
+        return sigma_mod;
+      };
+    // -------------------------------------------------------------------------
+
+    // -------------------- Get polarised background prediction ----------------
+    auto alphas_bkg_pol = linker_bkg_pol.get_all_bonded_fncts_at_bin(bin, pars);
+
+    // No longer sigma because includes lumi => #Events
+    auto pred_bkg_pol =
+      [ sigma_bkg_LR_mod,pol_factor_LR,
+        sigma_bkg_RL_mod,pol_factor_RL,
+        sigma_bkg_LL_mod,pol_factor_LL,
+        sigma_bkg_RR_mod,pol_factor_RR,
+        alphas_bkg_pol
+      ] () {
+        double sigma_mod =  pol_factor_LR() * sigma_bkg_LR_mod() +
+                            pol_factor_RL() * sigma_bkg_RL_mod() +
+                            pol_factor_LL() * sigma_bkg_LL_mod() +
+                            pol_factor_RR() * sigma_bkg_RR_mod();
+        for (const auto & alpha: alphas_bkg_pol) {sigma_mod *= alpha();}
+        return sigma_mod;
+      };
+    // -------------------------------------------------------------------------
+
+    // -------------------- Get total polarised prediction ---------------------
+    std::function<double()> pred_pol  =
+      [pred_sig_pol,pred_bkg_pol]() { return pred_sig_pol() + pred_bkg_pol(); };
+    // -------------------------------------------------------------------------
+
+    // -------------------- Set bin prediction function ------------------------
+    // Copy the bin values from the one in the distribution
+    Fit::FitBin connected_bin = diff_distr.m_distribution.at(bin);
+    connected_bin.set_prd_fct(pred_pol); // Set the prediction
+    bins->push_back(connected_bin);
+    // -------------------------------------------------------------------------
+  }
+}
+
+
+//------------------------------------------------------------------------------
+
+void DataConnector::fill_fit_container(
+  const Data::DiffDistrVec & diff_distrs,
+  const Fit::ParVec        & pars,
+  Fit::FitContainer *fit_container 
+) const {
+  
+  if (  (fit_container->m_fit_pars.size() != 0) ||
+        (fit_container->m_fit_bins.size() != 0)
+  ) {
+    throw std::invalid_argument("Can't fill non-empty fit container!");
+  }
+  
+  // Parameters are just to be copied, are created from diff. distrs. with 
+  // proper linking to the parameters in the fit container
+  fit_container->m_fit_pars = pars;
+  for ( const auto & distr : diff_distrs ) {
+    this->fill_bins(  
+      distr,
+      &(fit_container->m_fit_pars),
+      &(fit_container->m_fit_bins)
+    );
+  }
+}
+
+//------------------------------------------------------------------------------
+
+}
+}

--- a/source/prew/src/Connect/LinkHelp.cpp
+++ b/source/prew/src/Connect/LinkHelp.cpp
@@ -1,0 +1,83 @@
+#include <Connect/Linker.h>
+#include <Connect/LinkHelp.h>
+#include <Data/CoefDistr.h>
+#include <Data/FnctLink.h>
+#include <GlobalVar/Chiral.h>
+
+namespace PREW {
+namespace Connect {
+
+//------------------------------------------------------------------------------
+
+std::function<double()> LinkHelp::get_polfactor_lambda(
+  const std::string                         & chirality, 
+  const std::pair<std::string, std::string> & pol_pair, 
+  Fit::ParVec *pars
+) {
+  /** Get lambda function for the polarisation factor associated with a chiral
+      cross section. Lambda function output will be dependent on polarisation
+      fit parameters (whose names are in the pol pair).
+      In pol_pair: First string is electron polarisation parameter name, 
+                   second is positron polarisation parameter name.
+      Underlying equation:
+        (1 + e-_chirality * P_e-) * (1 + e+_chirality * P_e+) / 4
+  **/
+  
+  // Individual beam polarisation fit parameter names
+  std::string e_pol = pol_pair.first;
+  std::string p_pol = pol_pair.second;
+  
+  // Sign associated with a given chirality
+  Data::CoefDistrVec pol_coefs {
+    {"L", {}, {{-1}}},  // Left handed
+    {"R", {}, {{+1}}}   // Right handed
+  };
+  
+  // Chirality considered in the current cross section
+  std::string e_chirality {}, p_chirality {};
+  if ( chirality == GlobalVar::Chiral::eLpR ) {
+    e_chirality = "L";
+    p_chirality = "R";
+  } else if ( chirality == GlobalVar::Chiral::eRpL ) {
+    e_chirality = "R";
+    p_chirality = "L";
+  } else if ( chirality == GlobalVar::Chiral::eLpL ) {
+    e_chirality = "L";
+    p_chirality = "L";
+  } else if ( chirality == GlobalVar::Chiral::eRpR ) {
+    e_chirality = "R";
+    p_chirality = "R";
+  } else {
+    throw std::invalid_argument("Unknown chirality" + chirality);
+  }
+  
+  // Instruction class for how to build lambda function
+  Data::FnctLinkVec pol_fnct_link {
+    {"PolarisationFactor", {e_pol,p_pol}, {e_chirality,p_chirality} } };
+    
+  // Use Linker class to get function (Need one dummy 0 bin)
+  auto pol_factor = 
+    Connect::Linker(pol_fnct_link, {{0}}, pol_coefs)
+    .get_bonded_fnct_at_bin("PolarisationFactor",0,pars);
+
+  return pol_factor;
+}
+
+//------------------------------------------------------------------------------
+
+double LinkHelp::get_modified_sigma(
+  double sigma,
+  const std::vector<std::function<double()>>& alphas
+) {
+  /** Take a cross section (sigma) and alpha factor functions and return a 
+      function that gives the modified cross section value.
+  **/
+  double sigma_mod = sigma;
+  for (const auto & alpha: alphas) {sigma_mod *= alpha();}
+  return sigma_mod;
+}
+
+//------------------------------------------------------------------------------
+
+}
+}

--- a/source/prew/src/Connect/LinkHelp.cpp
+++ b/source/prew/src/Connect/LinkHelp.cpp
@@ -65,16 +65,20 @@ std::function<double()> LinkHelp::get_polfactor_lambda(
 
 //------------------------------------------------------------------------------
 
-double LinkHelp::get_modified_sigma(
+std::function<double()> LinkHelp::get_modified_sigma(
   double sigma,
   const std::vector<std::function<double()>>& alphas
 ) {
   /** Take a cross section (sigma) and alpha factor functions and return a 
       function that gives the modified cross section value.
   **/
-  double sigma_mod = sigma;
-  for (const auto & alpha: alphas) {sigma_mod *= alpha();}
-  return sigma_mod;
+  auto sigma_mod_fct = 
+    [sigma,alphas](){
+      double sigma_mod = sigma;
+      for (const auto & alpha: alphas) {sigma_mod *= alpha();}
+      return sigma_mod;
+    };
+  return sigma_mod_fct;
 }
 
 //------------------------------------------------------------------------------

--- a/source/prew/src/Connect/Linker.cpp
+++ b/source/prew/src/Connect/Linker.cpp
@@ -99,5 +99,25 @@ std::function<double()> Linker::get_bonded_fnct_at_bin (
 
 //------------------------------------------------------------------------------
 
+std::vector<std::function<double()>> Linker::get_all_bonded_fncts_at_bin(
+  size_t bin,
+  Fit::ParVec *pars
+) const {
+  /** Get all bonded parametrisation functions for the given bin.
+      (More details in get_bonded_fnct_at_bin)
+  **/
+  
+  std::vector<std::function<double()>> bonded_fncts_at_bin {};
+  for (const auto & fnct_link: m_fncts_links) {
+    bonded_fncts_at_bin.push_back(
+      get_bonded_fnct_at_bin(fnct_link.m_fnct_name, bin, pars)
+    );
+  }
+  
+  return bonded_fncts_at_bin;
+}
+
+//------------------------------------------------------------------------------
+
 }
 }

--- a/source/prew/src/Connect/Linker.cpp
+++ b/source/prew/src/Connect/Linker.cpp
@@ -1,0 +1,103 @@
+#include <Connect/Linker.h>
+#include <CppUtils/Vec.h>
+#include <Fncts/FnctMap.h>
+
+#include "spdlog/spdlog.h"
+
+#include <functional>
+#include <exception>
+#include <string>
+#include <vector>
+
+namespace PREW {
+namespace Connect {
+
+//------------------------------------------------------------------------------
+// Constructors
+
+Linker::Linker( Data::FnctLinkVec fncts_links,
+                CppUtils::Vec::Matrix2D<double> bin_centers,
+                Data::CoefDistrVec coefs 
+) : m_fncts_links(fncts_links),
+    m_bin_centers(bin_centers),
+    m_coefs(coefs) 
+{}
+
+//------------------------------------------------------------------------------
+
+std::function<double()> Linker::get_bonded_fnct_at_bin (
+  const std::string &fnct_name,
+  size_t bin,
+  Fit::ParVec *pars
+) const {
+  /** Return the requested parameterisation function in which the values of
+      bin centers and coefficients are fixed (to their values at the bin),
+      and for which the parameters are connected to the given pointers.
+      This means that if parameters are changed the output of the bounded 
+      function will change.
+  **/
+  
+  if (bin > m_bin_centers.size()) {
+    throw std::out_of_range("Asking for function for non-existing bin!");
+  }
+  std::vector<double> bin_center = m_bin_centers[bin];
+
+  // Find link of function (names of pars and coefs to be used)
+  auto name_condition = 
+    [fnct_name](const Data::FnctLink &link) {
+      return link.m_fnct_name == fnct_name;
+    };
+  Data::FnctLink fnct_link = 
+    CppUtils::Vec::element_by_condition(m_fncts_links, name_condition);
+
+  // Find needed coefficient values
+  spdlog::debug("Looking for {} coefficients.", fnct_link.m_coefs.size());
+  std::vector<double> bin_coefs {};
+  for ( const auto & coef_name: fnct_link.m_coefs ) {
+    // Find coefficient distribution with given name
+    auto name_condition = [coef_name](const Data::CoefDistr& coef_distr) 
+                            {return coef_distr.m_coef_name==coef_name;};
+    auto coefs = CppUtils::Vec::element_by_condition(m_coefs, name_condition);
+    // Choose coeffient value at bin
+    bin_coefs.push_back(coefs.m_coefficients[bin]);
+  }
+  spdlog::debug("Found {} coefficients.", bin_coefs.size());
+  
+  // Find pointers to needed parameters
+  spdlog::debug("Looking for {} parameters.", fnct_link.m_pars.size());
+  std::vector<double*> bin_pars {};
+  for ( auto & par_name: fnct_link.m_pars ) {
+    // Find the index of the correct parameter and connect the modifiable 
+    // parameter value in with the function
+    for (size_t i_par=0; i_par<pars->size(); i_par++) {
+      if ( (*pars)[i_par].get_name() == par_name ) {
+        // Found correct parameter, use pointer to its modifiable value
+        bin_pars.push_back( & ((*pars)[i_par].m_val_mod) );
+        continue;
+      }
+    }
+  }
+  spdlog::debug("Found {} parameters.", bin_pars.size());
+  
+  // Check if requested function exists
+  if ( Fncts::prew_fnct_map.find(fnct_name) == Fncts::prew_fnct_map.end() ) {
+    throw std::invalid_argument("Function not known: " + fnct_name);
+  }
+  
+  // Fix the arguments of the requested function:
+  // Bin center and coefficient values are fixed, parameter pointers are fixed.
+  std::function<double()> bound_fnct = 
+   std::bind( 
+     Fncts::prew_fnct_map.at(fnct_name),
+     bin_center,
+     bin_coefs,
+     bin_pars
+   );
+
+  return bound_fnct;
+}
+
+//------------------------------------------------------------------------------
+
+}
+}

--- a/source/prew/src/CppUtils/Str.cpp
+++ b/source/prew/src/CppUtils/Str.cpp
@@ -1,0 +1,34 @@
+#include <CppUtils/Str.h>
+
+namespace PREW {
+namespace CppUtils {
+
+//------------------------------------------------------------------------------
+
+
+std::vector<std::string> Str::string_to_vec( 
+  const std::string &str, 
+  std::string delimiter ) 
+{
+  /** Splits string into vector of substrings.
+      Splitting is defined by the given delimiter (default=whitespace).
+  **/
+  std::vector<std::string> substrings {};
+  size_t last = 0; size_t next = 0;
+  std::string substring {};
+  while ( (next = str.find(delimiter, last) ) != std::string::npos ) {
+    substring = str.substr(last, next-last);
+    last = next + 1; 
+    if ( substring != "" ) { substrings.push_back(substring); }
+  }
+  substring = str.substr(last);
+  if ( substring != "" ) { substrings.push_back(substring); }
+  
+  return substrings;
+}
+
+
+//------------------------------------------------------------------------------
+  
+}
+}

--- a/source/prew/src/Data/DistrInfo.cpp
+++ b/source/prew/src/Data/DistrInfo.cpp
@@ -1,0 +1,18 @@
+#include <Data/DistrInfo.h>
+
+namespace PREW {
+namespace Data {
+
+//------------------------------------------------------------------------------
+// Operators
+
+bool DistrInfo::operator==(const DistrInfo& other) const {
+  return  (m_distr_name == other.m_distr_name) &&
+          (m_pol_config == other.m_pol_config) &&
+          (m_energy == other.m_energy);
+}
+
+//------------------------------------------------------------------------------
+
+}
+}

--- a/source/prew/src/Fit/ChiSqMinimizer.cpp
+++ b/source/prew/src/Fit/ChiSqMinimizer.cpp
@@ -12,7 +12,7 @@ namespace Fit {
 //------------------------------------------------------------------------------
 // Constructors
 
-ChiSqMinimizer::ChiSqMinimizer(FitContainer * container, MinuitFactory &factory) : 
+ChiSqMinimizer::ChiSqMinimizer(FitContainer * container, const MinuitFactory &factory) : 
   m_container(container) 
 {
   this->update_chisq();
@@ -23,7 +23,7 @@ ChiSqMinimizer::ChiSqMinimizer(FitContainer * container, MinuitFactory &factory)
 // get functions
 
 double ChiSqMinimizer::get_chisq() const { return m_chisq; }
-FitResult ChiSqMinimizer::get_result() const { return m_result; }
+const FitResult& ChiSqMinimizer::get_result() const { return m_result; }
 
 //------------------------------------------------------------------------------
 // Core functionality
@@ -88,7 +88,7 @@ void ChiSqMinimizer::minimize() {
 }
 
 //------------------------------------------------------------------------------
-// Result collectiong
+// Result collecting
 
 void ChiSqMinimizer::collect_par_names() {
   unsigned int n_pars = m_container->m_fit_pars.size();

--- a/source/prew/src/Fit/FitBin.cpp
+++ b/source/prew/src/Fit/FitBin.cpp
@@ -10,6 +10,11 @@ FitBin::FitBin(double val_mst, double val_unc, std::function<double()> prd_fct) 
   m_val_mst(val_mst), m_val_unc(val_unc), m_prd_fct(prd_fct) {}
 
 //------------------------------------------------------------------------------
+// set functions
+
+void FitBin::set_prd_fct(std::function<double()> prd_fct) {m_prd_fct = prd_fct;}
+
+//------------------------------------------------------------------------------
 // get functions
 
 double FitBin::get_val_mst() const { return m_val_mst; }

--- a/source/prew/src/Fit/ParConstrGauss.cpp
+++ b/source/prew/src/Fit/ParConstrGauss.cpp
@@ -1,4 +1,5 @@
 #include <Fit/ParConstrGauss.h>
+#include <CppUtils/Num.h>
 
 #include <cmath>
 
@@ -16,6 +17,22 @@ ParConstrGauss::ParConstrGauss(double val, double unc) :
 
 double ParConstrGauss::calc_chisq(double par_val) const {
   return std::pow( (par_val - m_val) / m_unc, 2 );
+}
+
+//------------------------------------------------------------------------------
+// Reader functions
+
+double ParConstrGauss::get_val() const { return m_val; }
+double ParConstrGauss::get_unc() const { return m_unc; }
+
+//------------------------------------------------------------------------------
+// Operators
+
+bool ParConstrGauss::operator==(const ParConstrGauss& other) const {
+  /** Compare the value and uncertainty using 10_{-9} precision.
+  **/
+  return CppUtils::Num::equal_to_eps(m_val, other.get_val(), 1e-9) &&
+         CppUtils::Num::equal_to_eps(m_unc, other.get_unc(), 1e-9);
 }
 
 //------------------------------------------------------------------------------

--- a/source/prew/src/Fncts/Physics.cpp
+++ b/source/prew/src/Fncts/Physics.cpp
@@ -1,0 +1,25 @@
+#include <Fncts/Physics.h>
+
+namespace PREW {
+namespace Fncts {
+
+//------------------------------------------------------------------------------
+
+double Physics::polarisation_factor ( 
+  const std::vector<double> &/*x*/,
+  const std::vector<double> &c,
+  const std::vector<double*> &p
+) {
+  /** Calculate polarisation factor for given chirality (handled by 
+      coeffficients) and polarisations (handled by parameters).
+      Coefficients: c[0] - electron chirality (-1 = L , +1 = R)
+                    c[1] - positron chirality (-1 = L , +1 = R)
+      Parameters: p[0] - electron beam polarisation
+                  p[1] - positron beam polarisation
+  **/
+  
+  return 0.25 * ( 1 + c[0] * (*(p[0])) ) * ( 1 + c[1] * (*(p[1])) );
+}
+
+}
+}

--- a/source/prew/src/Fncts/Polynomial.cpp
+++ b/source/prew/src/Fncts/Polynomial.cpp
@@ -1,0 +1,26 @@
+#include <Fncts/Polynomial.h>
+
+#include <math.h>
+
+namespace PREW {
+namespace Fncts {
+
+//------------------------------------------------------------------------------
+
+double Polynomial::quadratic_1D ( 
+  const std::vector<double> &x,
+  const std::vector<double> &/*c*/,
+  const std::vector<double*> &p
+) {
+  /** Gaussian function in 1D.
+      Parameters: p[0] - offset
+                  p[1] - linear coeff
+                  p[2] - quadratic coeff
+      No coefficients required.
+  **/
+  
+  return (*(p[0])) + (*(p[1])) * x[0] + (*(p[2])) * std::pow( x[0], 2);
+}
+
+}
+}

--- a/source/prew/src/Fncts/Statistic.cpp
+++ b/source/prew/src/Fncts/Statistic.cpp
@@ -1,0 +1,28 @@
+#include <Fncts/Statistic.h>
+
+#include <exception>
+#include <math.h>
+
+namespace PREW {
+namespace Fncts {
+
+//------------------------------------------------------------------------------
+
+double Statistic::gaussian_1D ( 
+  const std::vector<double> &x,
+  const std::vector<double> &/*c*/,
+  const std::vector<double*> &p
+) {
+  /** Gaussian function in 1D.
+      Parameters: p[0] - amplitude
+                  p[1] - mean
+                  p[2] - width
+      No coefficients required.
+  **/
+  
+  return (*(p[0])) / (  (*(p[2])) * std::sqrt(2.0*M_PI) ) 
+         * std::exp( -0.5 * std::pow( ( x[0] - (*(p[1])) ) / (*(p[2])) ,2) );
+}
+
+}
+}

--- a/source/prew/src/Input/DataReader.cpp
+++ b/source/prew/src/Input/DataReader.cpp
@@ -41,6 +41,8 @@ Data::DiffDistrVec DataReader::get_meas_distrs() const { return m_meas_distrs; }
 
 Data::PredDistrVec DataReader::get_pred_distrs() const { return m_pred_distrs; }
 
+Data::CoefDistrVec DataReader::get_coef_distrs() const { return m_coef_distrs; }
+
 //------------------------------------------------------------------------------
 
 }

--- a/source/prew/src/Input/DataReader.cpp
+++ b/source/prew/src/Input/DataReader.cpp
@@ -34,7 +34,7 @@ void DataReader::read_file() {
 
 //------------------------------------------------------------------------------
 
-Data::Distr1DVec DataReader::get_distributions() const {
+Data::DiffDistrVec DataReader::get_distributions() const {
   return m_distributions;
 }
 

--- a/source/prew/src/Input/DataReader.cpp
+++ b/source/prew/src/Input/DataReader.cpp
@@ -39,11 +39,17 @@ void DataReader::read_file() {
 
 //------------------------------------------------------------------------------
 
-Data::DiffDistrVec DataReader::get_meas_distrs() const { return m_meas_distrs; }
+const Data::DiffDistrVec& DataReader::get_meas_distrs() const {
+ return m_meas_distrs; 
+}
 
-Data::PredDistrVec DataReader::get_pred_distrs() const { return m_pred_distrs; }
+const Data::PredDistrVec& DataReader::get_pred_distrs() const {
+ return m_pred_distrs; 
+}
 
-Data::CoefDistrVec DataReader::get_coef_distrs() const { return m_coef_distrs; }
+const Data::CoefDistrVec& DataReader::get_coef_distrs() const {
+ return m_coef_distrs; 
+}
 
 //------------------------------------------------------------------------------
 

--- a/source/prew/src/Input/DataReader.cpp
+++ b/source/prew/src/Input/DataReader.cpp
@@ -10,8 +10,8 @@ namespace Input {
 //------------------------------------------------------------------------------
 // Constructors
 
-DataReader::DataReader(InputInfo *input_info, std::string input_style) :
-  m_input_info(input_info), m_input_style(input_style) 
+DataReader::DataReader(InputInfo *input_info) :
+  m_input_info(input_info)
 {
   if ( ! CppUtils::Sys::file_exists(input_info->m_file_path) ) {
     throw std::invalid_argument(("File not found: " + input_info->m_file_path).c_str());
@@ -27,11 +27,12 @@ void DataReader::read_file() {
       type.
   **/
   
-  if ( m_input_style == "RK" ) {
+  if ( m_input_info->m_input_style == "RK" ) {
     spdlog::debug("Reading RK style file, these only contain predictions and coefficients, no measurement.");
     Reading::read_RK_file(m_input_info, &m_pred_distrs, &m_coef_distrs);
   } else {
-    throw std::invalid_argument(("Invalid file style " + m_input_style).c_str());
+    throw std::invalid_argument(
+      ("Invalid file style " + m_input_info->m_input_style).c_str() );
   }
 }
 

--- a/source/prew/src/Input/DataReader.cpp
+++ b/source/prew/src/Input/DataReader.cpp
@@ -2,6 +2,7 @@
 #include <Input/DataReader.h>
 
 #include <exception>
+#include "spdlog/spdlog.h"
 
 namespace PREW {
 namespace Input {
@@ -22,10 +23,12 @@ DataReader::DataReader(InputInfo *input_info, std::string input_style) :
 void DataReader::read_file() {
   /** Read the file whose info is provided in input_info according to the 
       given style of input file.
+      Could read measurement and or prediction depending on file type.
   **/
   
   if ( m_input_style == "RK" ) {
-    m_distributions = Reading::read_RK_file(m_input_info);
+    spdlog::debug("Reading RK style file, these only contain predictions.");
+    m_pred_distrs = Reading::read_RK_file(m_input_info);
   } else {
     throw std::invalid_argument(("Invalid file style " + m_input_style).c_str());
   }
@@ -34,9 +37,9 @@ void DataReader::read_file() {
 
 //------------------------------------------------------------------------------
 
-Data::DiffDistrVec DataReader::get_distributions() const {
-  return m_distributions;
-}
+Data::DiffDistrVec DataReader::get_meas_distrs() const { return m_meas_distrs; }
+
+Data::PredDistrVec DataReader::get_pred_distrs() const { return m_pred_distrs; }
 
 //------------------------------------------------------------------------------
 

--- a/source/prew/src/Input/DataReader.cpp
+++ b/source/prew/src/Input/DataReader.cpp
@@ -23,12 +23,13 @@ DataReader::DataReader(InputInfo *input_info, std::string input_style) :
 void DataReader::read_file() {
   /** Read the file whose info is provided in input_info according to the 
       given style of input file.
-      Could read measurement and or prediction depending on file type.
+      Could read measurement, prediction and/or coefficients depending on file
+      type.
   **/
   
   if ( m_input_style == "RK" ) {
-    spdlog::debug("Reading RK style file, these only contain predictions.");
-    m_pred_distrs = Reading::read_RK_file(m_input_info);
+    spdlog::debug("Reading RK style file, these only contain predictions and coefficients, no measurement.");
+    Reading::read_RK_file(m_input_info, &m_pred_distrs, &m_coef_distrs);
   } else {
     throw std::invalid_argument(("Invalid file style " + m_input_style).c_str());
   }

--- a/source/prew/src/Input/Reading.cpp
+++ b/source/prew/src/Input/Reading.cpp
@@ -1,6 +1,6 @@
 #include <CppUtils/Vec.h>
 #include <CppUtils/Root.h>
-#include <Data/Distr1D.h>
+#include <Data/DiffDistr.h>
 #include <Fit/FitBin.h>
 #include <Input/Reading.h>
 #include <Input/InfoRKFile.h>
@@ -14,11 +14,11 @@ namespace Input {
   
 //------------------------------------------------------------------------------
 
-Data::Distr1DVec Reading::read_RK_file(InputInfo *input_info) {
+Data::DiffDistrVec Reading::read_RK_file(InputInfo *input_info) {
   /** Read input file that is in style of Robert Karls root files.
   **/
   
-  Data::Distr1DVec distributions {};
+  Data::DiffDistrVec distributions {};
 
   // Get all the information needed to read the file
   InfoRKFile* info = static_cast<InfoRKFile*>(input_info);
@@ -77,10 +77,10 @@ Data::Distr1DVec Reading::read_RK_file(InputInfo *input_info) {
   for(int p=0; p<n_processes; p++){
     tree->GetEntry(p);
     
-    Data::Distr1D distr_LL {};
-    Data::Distr1D distr_LR {};
-    Data::Distr1D distr_RL {};
-    Data::Distr1D distr_RR {};
+    Data::DiffDistr distr_LL {};
+    Data::DiffDistr distr_LR {};
+    Data::DiffDistr distr_RL {};
+    Data::DiffDistr distr_RR {};
     
     distr_LL.m_info.m_pol_config = "LL";
     distr_LR.m_info.m_pol_config = "LR";

--- a/source/prew/src/Input/Reading.cpp
+++ b/source/prew/src/Input/Reading.cpp
@@ -3,6 +3,7 @@
 #include <CppUtils/Vec.h>
 #include <Data/PredDistr.h>
 #include <Fit/FitBin.h>
+#include <GlobalVar/Chiral.h>
 #include <Input/InfoRKFile.h>
 #include <Input/Reading.h>
 
@@ -80,6 +81,7 @@ void Reading::read_RK_file(
   for(int p=0; p<n_processes; p++){
     tree->GetEntry(p);
     
+    // Info that identifies distribution
     Data::DistrInfo basic_info {};
     basic_info.m_energy = energy;
     basic_info.m_process_name = *process;
@@ -89,10 +91,10 @@ void Reading::read_RK_file(
                     info_RL = basic_info,
                     info_RR = basic_info;
                     
-    info_LL.m_pol_config = "LL";
-    info_LR.m_pol_config = "LR";
-    info_RL.m_pol_config = "RL";
-    info_RR.m_pol_config = "RR";
+    info_LL.m_pol_config = GlobalVar::Chiral::eLpL;
+    info_LR.m_pol_config = GlobalVar::Chiral::eLpR;
+    info_RL.m_pol_config = GlobalVar::Chiral::eRpL;
+    info_RR.m_pol_config = GlobalVar::Chiral::eRpR;
 
     Data::PredDistr pred_LL {}, pred_LR {}, pred_RL {}, pred_RR {};
     pred_LL.m_info = info_LL;
@@ -100,6 +102,7 @@ void Reading::read_RK_file(
     pred_RL.m_info = info_RL;
     pred_RR.m_info = info_RR;
     
+    // Reading of actual distribution and coefficients
     CppUtils::Vec::Matrix2D<double> bin_center_mtx 
       = CppUtils::Root::matrix2D_from_TMatrixT( *bin_centers );
     pred_LL.m_bin_centers = bin_center_mtx;
@@ -130,6 +133,7 @@ void Reading::read_RK_file(
       }
     }
     
+    // Saving distributions in given pointers
     pred_distrs->push_back(pred_LL);
     pred_distrs->push_back(pred_LR);
     pred_distrs->push_back(pred_RL);

--- a/source/prew/src/Input/Reading.cpp
+++ b/source/prew/src/Input/Reading.cpp
@@ -100,7 +100,6 @@ void Reading::read_RK_file(
     pred_RL.m_info = info_RL;
     pred_RR.m_info = info_RR;
     
-    // 
     CppUtils::Vec::Matrix2D<double> bin_center_mtx 
       = CppUtils::Root::matrix2D_from_TMatrixT( *bin_centers );
     pred_LL.m_bin_centers = bin_center_mtx;
@@ -116,16 +115,12 @@ void Reading::read_RK_file(
     for (auto & coef: coefs_LR) { coef.m_info = info_LR; }
     for (auto & coef: coefs_RL) { coef.m_info = info_RL; }
     for (auto & coef: coefs_RR) { coef.m_info = info_RR; }
-    // coef_LL.m_info = info_LL;
-    // coef_LR.m_info = info_LR;
-    // coef_RL.m_info = info_RL;
-    // coef_RR.m_info = info_RR;
     
     for (int bin=0; bin<n_bins; bin++) {
-      pred_LL.m_distribution.push_back( diff_sigma_signal_LL[bin] );
-      pred_LR.m_distribution.push_back( diff_sigma_signal_LR[bin] );
-      pred_RL.m_distribution.push_back( diff_sigma_signal_RL[bin] );
-      pred_RR.m_distribution.push_back( diff_sigma_signal_RR[bin] );
+      pred_LL.m_sig_distr.push_back( diff_sigma_signal_LL[bin] );
+      pred_LR.m_sig_distr.push_back( diff_sigma_signal_LR[bin] );
+      pred_RL.m_sig_distr.push_back( diff_sigma_signal_RL[bin] );
+      pred_RR.m_sig_distr.push_back( diff_sigma_signal_RR[bin] );
       
       for (size_t coef=0; coef<n_coefs; coef++) {
         coefs_LL[coef].m_coefficients.push_back((*diff_TGC_coeff_LL)[bin][coef]);

--- a/source/prew/src/Input/Reading.cpp
+++ b/source/prew/src/Input/Reading.cpp
@@ -82,20 +82,20 @@ Data::Distr1DVec Reading::read_RK_file(InputInfo *input_info) {
     Data::Distr1D distr_RL {};
     Data::Distr1D distr_RR {};
     
-    distr_LL.m_pol_config = "LL";
-    distr_LR.m_pol_config = "LR";
-    distr_RL.m_pol_config = "RL";
-    distr_RR.m_pol_config = "RR";
+    distr_LL.m_info.m_pol_config = "LL";
+    distr_LR.m_info.m_pol_config = "LR";
+    distr_RL.m_info.m_pol_config = "RL";
+    distr_RR.m_info.m_pol_config = "RR";
     
-    distr_LL.m_energy = energy;
-    distr_LR.m_energy = energy;
-    distr_RL.m_energy = energy;
-    distr_RR.m_energy = energy;
+    distr_LL.m_info.m_energy = energy;
+    distr_LR.m_info.m_energy = energy;
+    distr_RL.m_info.m_energy = energy;
+    distr_RR.m_info.m_energy = energy;
     
-    distr_LL.m_process_name = *process;
-    distr_LR.m_process_name = *process;
-    distr_RL.m_process_name = *process;
-    distr_RR.m_process_name = *process;
+    distr_LL.m_info.m_process_name = *process;
+    distr_LR.m_info.m_process_name = *process;
+    distr_RL.m_info.m_process_name = *process;
+    distr_RR.m_info.m_process_name = *process;
     
     CppUtils::Vec::Matrix2D<double> bin_center_mtx 
       = CppUtils::Root::matrix2D_from_TMatrixT( *bin_centers );

--- a/source/prew/src/Input/Reading.cpp
+++ b/source/prew/src/Input/Reading.cpp
@@ -84,7 +84,7 @@ void Reading::read_RK_file(
     // Info that identifies distribution
     Data::DistrInfo basic_info {};
     basic_info.m_energy = energy;
-    basic_info.m_process_name = *process;
+    basic_info.m_distr_name = *process;
     
     Data::DistrInfo info_LL = basic_info,
                     info_LR = basic_info,

--- a/source/prew/src/Input/Reading.cpp
+++ b/source/prew/src/Input/Reading.cpp
@@ -1,6 +1,6 @@
 #include <CppUtils/Vec.h>
 #include <CppUtils/Root.h>
-#include <Data/DiffDistr.h>
+#include <Data/PredDistr.h>
 #include <Fit/FitBin.h>
 #include <Input/Reading.h>
 #include <Input/InfoRKFile.h>
@@ -14,11 +14,11 @@ namespace Input {
   
 //------------------------------------------------------------------------------
 
-Data::DiffDistrVec Reading::read_RK_file(InputInfo *input_info) {
+Data::PredDistrVec Reading::read_RK_file(InputInfo *input_info) {
   /** Read input file that is in style of Robert Karls root files.
   **/
   
-  Data::DiffDistrVec distributions {};
+  Data::PredDistrVec distributions {};
 
   // Get all the information needed to read the file
   InfoRKFile* info = static_cast<InfoRKFile*>(input_info);
@@ -77,10 +77,10 @@ Data::DiffDistrVec Reading::read_RK_file(InputInfo *input_info) {
   for(int p=0; p<n_processes; p++){
     tree->GetEntry(p);
     
-    Data::DiffDistr distr_LL {};
-    Data::DiffDistr distr_LR {};
-    Data::DiffDistr distr_RL {};
-    Data::DiffDistr distr_RR {};
+    Data::PredDistr distr_LL {};
+    Data::PredDistr distr_LR {};
+    Data::PredDistr distr_RL {};
+    Data::PredDistr distr_RR {};
     
     distr_LL.m_info.m_pol_config = "LL";
     distr_LR.m_info.m_pol_config = "LR";
@@ -105,10 +105,10 @@ Data::DiffDistrVec Reading::read_RK_file(InputInfo *input_info) {
     distr_RR.m_bin_centers = bin_center_mtx;
     
     for (int bin=0; bin<n_bins; bin++) {
-      distr_LL.m_distribution.push_back( Fit::FitBin(diff_sigma_signal_LL[bin],0) );
-      distr_LR.m_distribution.push_back( Fit::FitBin(diff_sigma_signal_LR[bin],0) );
-      distr_RL.m_distribution.push_back( Fit::FitBin(diff_sigma_signal_RL[bin],0) );
-      distr_RR.m_distribution.push_back( Fit::FitBin(diff_sigma_signal_RR[bin],0) );
+      distr_LL.m_distribution.push_back( diff_sigma_signal_LL[bin] );
+      distr_LR.m_distribution.push_back( diff_sigma_signal_LR[bin] );
+      distr_RL.m_distribution.push_back( diff_sigma_signal_RL[bin] );
+      distr_RR.m_distribution.push_back( diff_sigma_signal_RR[bin] );
     }
     
     // TODO Add when know what to do with TGC parameters

--- a/source/prew/src/ToyMeas/ToyGenerator.cpp
+++ b/source/prew/src/ToyMeas/ToyGenerator.cpp
@@ -1,0 +1,133 @@
+#include <Connect/DataConnector.h>
+#include <Connect/Linker.h>
+#include <CppUtils/Map.h>
+#include <Data/DistrInfo.h>
+#include <Data/DistrUtils.h>
+#include <GlobalVar/Chiral.h>
+#include <ToyMeas/ToyGenerator.h>
+
+#include "spdlog/spdlog.h"
+
+#include <algorithm>
+#include <cmath>
+#include <exception>
+
+namespace PREW {
+namespace ToyMeas {
+
+//------------------------------------------------------------------------------
+// Constructors
+
+ToyGenerator::ToyGenerator(
+  const Connect::DataConnector & connector,
+  const Fit::ParVec & pars
+) : m_connector(connector), m_pars(pars) 
+{
+  // TODO DESCRIPTION!!!
+  
+  if (m_connector.get_pred_distrs().size() == 0) {
+    spdlog::warn("No predicted distributions supplied!");
+  }
+  
+  // First figure energies and available distributions and polarisation configs
+  // for each energy
+  std::set<int> energies {};
+  CppUtils::Map::IntToStrSetMap distr_per_energies {};
+  CppUtils::Map::IntToStrSetMap pol_configs_per_energies {};
+  for (const auto & distr: m_connector.get_pred_distrs()) {
+    int energy = distr.m_info.m_energy;
+    energies.insert(energy);
+    distr_per_energies[energy].insert(distr.m_info.m_distr_name);
+    
+    // Find polarisation link for this energy 
+    // => which polarisations exist?
+    auto energy_condition = 
+      [energy](const Data::PolLink& link) {return link.m_energy==energy;};
+    Data::PolLink pol_link = 
+      CppUtils::Vec::element_by_condition( m_connector.get_pol_links(), energy_condition );
+      
+    // Find all available polarisations at energy from polarisation link
+    for (const auto& [pol_config, pol_pair]: pol_link.m_config_pol_links) {
+      pol_configs_per_energies[energy].insert(pol_config);
+    }
+    // TODO This as functionality of connector?????
+  }
+  
+  // Check what was found
+  for (const int & energy: energies) {
+    // TODO Map function to check if element exists TODO
+    if (pol_configs_per_energies.find(energy)==pol_configs_per_energies.end()) {
+      spdlog::warn("For E={} no pol. config. found!", energy);
+      continue;
+    }
+    spdlog::debug(
+      "For E={} found {} distribution and {} pol. configurations.",
+      distr_per_energies.at(energy).size(), 
+      pol_configs_per_energies.at(energy).size()
+    );
+  }
+  
+  // Loop over all distributions found at their respective energies
+  for (const int & energy: energies) {
+    for (const auto & distr_name: distr_per_energies.at(energy)) {
+      // Get distribution setup bin centers from first prediction
+      auto predictions = 
+        Data::DistrUtils::subvec_energy_and_name(m_connector.get_pred_distrs(),energy,distr_name);
+      auto bin_centers = predictions.at(0).m_bin_centers;
+        
+      // Loop over all polarisations for the given energy
+      for (const auto& pol_config: pol_configs_per_energies.at(energy)) {
+        
+        // Create a differential distribution for this polarisation config.
+        // Fit bins empty for now, prediction to be set
+        Data::DistrInfo current_info { distr_name, pol_config, energy };
+        Data::DiffDistr distribution {};
+        distribution.m_info = current_info;
+        distribution.m_bin_centers = bin_centers;
+        distribution.m_distribution = Fit::BinVec(bin_centers.size());
+        
+        // Fix the bin predictions and link them to the given fit parameters
+        Fit::BinVec connected_bins {};
+        m_connector.fill_bins(
+          distribution,
+          &m_pars,
+          &connected_bins
+        );
+        distribution.m_distribution = connected_bins;
+        
+        m_diff_distrs.push_back(distribution);
+      } // End pol config loop
+    } // End diff distr loop
+  } // End energy loop
+}
+
+//------------------------------------------------------------------------------
+// Functions to get distributions which were generated from predictions
+
+Data::DiffDistrVec ToyGenerator::get_expected_distrs ( int energy ) const {
+  // TODO TODO TODO COMMENT!!!
+  auto distrs = Data::DistrUtils::subvec_energy(m_diff_distrs, energy);
+  
+  Data::DiffDistrVec output_distrs {};
+  for ( const auto & distr: distrs ) {
+    Data::DiffDistr output_distr {
+      distr.m_info,
+      distr.m_bin_centers,
+      {} // Bin contents to be set now
+    };
+    
+    for ( const auto & bin : distr.m_distribution ) {
+      output_distr.m_distribution.push_back(
+        Fit::FitBin(bin.get_val_prd(), std::sqrt(bin.get_val_prd()))
+      );
+    }
+    output_distrs.push_back(output_distr);
+  }
+  
+  return output_distrs;
+}
+
+//------------------------------------------------------------------------------
+  
+}
+}

--- a/source/tests/Connect/test_DataConnector.cpp
+++ b/source/tests/Connect/test_DataConnector.cpp
@@ -1,0 +1,116 @@
+#include <Connect/DataConnector.h>
+#include <CppUtils/Num.h>
+#include <CppUtils/Vec.h>
+#include <Data/CoefDistr.h>
+#include <Data/DistrInfo.h>
+#include <Data/PolLink.h>
+#include <Data/PredDistr.h>
+#include <Fit/FitBin.h>
+#include <Fit/FitContainer.h>
+#include <Fit/FitPar.h>
+#include <GlobalVar/Chiral.h>
+
+#include <gtest/gtest.h>
+
+using namespace PREW::Connect;
+using namespace PREW::CppUtils;
+using namespace PREW::Data;
+using namespace PREW::Fit;
+using namespace PREW::GlobalVar;
+
+//------------------------------------------------------------------------------
+// Tests for DataConnector class that links prediction
+
+TEST(TestDataConnector, EmptyConstructor) {
+  // DataConnector needs at least polarisation links and predicitions
+  ASSERT_THROW(
+    DataConnector(),
+    std::invalid_argument
+  );
+}
+
+TEST(TestDataConnector, ReadFunctions) {
+  // Simple sanity check that read functions return correct vectors
+  DistrInfo info_LR {"test", Chiral::eLpR, 500};
+  DistrInfo info_RL {"test", Chiral::eRpL, 500};
+  Vec::Matrix2D<double> bin_centers = {{0}, {1}};
+  PredDistrVec pred_distrs { 
+    { info_LR, bin_centers, {1}, {0} }, 
+    { info_LR, bin_centers, {2}, {0} } 
+  };
+  CoefDistrVec coef_distrs {};
+  PredLinkVec  pred_links {
+    { info_LR, { {"Gaussian1D", {"A_LR", "mu", "sigma"}} }, {} },
+  };
+  PolLinkVec   pol_links { {500, { {"e-p+", {"ePol", "pPol"}} }} };
+  
+  DataConnector connector {pred_distrs,coef_distrs,pred_links,pol_links};
+
+  // Here simple size check
+  ASSERT_EQ( connector.get_pred_distrs().size(), 2 );
+  ASSERT_EQ( connector.get_coef_distrs().size(), 0 );
+  ASSERT_EQ( connector.get_pred_links().size(), 1 );
+  ASSERT_EQ( connector.get_pol_links().size(), 1 );
+}
+
+TEST(TestDataConnector, DistrFilling) {
+  // Test on a simple example that filling of a bin vector works properly
+  
+  // Create some distributions with predictions to test bin connecting
+  DistrInfo info_pol {"test", "e-p+", 500};
+  DistrInfo info_LR {"test", Chiral::eLpR, 500};
+  DistrInfo info_RL {"test", Chiral::eRpL, 500};
+  DistrInfo info_LL {"test", Chiral::eLpL, 500};
+  DistrInfo info_RR {"test", Chiral::eRpR, 500};
+  Vec::Matrix2D<double> bin_centers = {{0}, {1}};
+  DiffDistr diff_distr { info_pol, bin_centers, {{0.8,0.2},{1,0.2}} };
+  PredDistrVec pred_distrs { 
+    { info_LR, bin_centers, {1}, {0} },
+    { info_RL, bin_centers, {1}, {0} },
+    { info_LL, bin_centers, {1}, {0} },
+    { info_RR, bin_centers, {1}, {0} },
+  };
+  ParVec pars { 
+    {"A_pol", 1, 0},
+    {"A_LR", 1, 0},
+    {"mu", 0, 0},
+    {"sigma", 0.5, 0},
+    {"ePol", -0.80, 0},
+    {"pPol", +0.30, 0}
+  };
+  CoefDistrVec coef_distrs {};
+  PredLinkVec  pred_links {
+    { info_LR, { {"Gaussian1D", {"A_LR", "mu", "sigma"}} }, {} },
+    { info_RL, {}, {} },
+    { info_LL, {}, {} },
+    { info_RR, {}, {} },
+    { info_pol, { {"Gaussian1D", {"A_pol", "mu", "sigma"}} }, {} }
+  };
+  PolLinkVec   pol_links {
+    {500, { {"e-p+", {"ePol", "pPol"}} }}
+  };
+  
+  // Connector has task to connect all of that
+  DataConnector connector {pred_distrs,coef_distrs,pred_links,pol_links};
+  
+  // Test on single distribution
+  BinVec bins {};
+  connector.fill_bins(diff_distr, &pars, &bins);
+  
+  double bin0_val = bins[0].get_val_mst();
+  double bin0_unc = bins[0].get_val_unc();
+  double bin0_pred = bins[0].get_val_prd();
+  ASSERT_EQ( Num::equal_to_eps(bin0_val, 0.8, 1e-9), true );
+  ASSERT_EQ( Num::equal_to_eps(bin0_unc, 0.2, 1e-9), true );
+  ASSERT_EQ( Num::equal_to_eps(bin0_pred, 0.70354465956, 1e-9), true )
+    << "Expected " << 0.70354465956 << " got " << bin0_pred;
+    
+  // Test on distribution vector (=> fills fit container)
+  DiffDistrVec distr_vec {diff_distr};
+  FitContainer fit_container {};
+  connector.fill_fit_container( distr_vec, pars, &fit_container );
+  ASSERT_EQ( fit_container.m_fit_pars.size(), 6 );
+  ASSERT_EQ( fit_container.m_fit_bins.size(), 2 );
+}
+
+//------------------------------------------------------------------------------

--- a/source/tests/Connect/test_LinkHelp.cpp
+++ b/source/tests/Connect/test_LinkHelp.cpp
@@ -49,15 +49,18 @@ TEST(TestLinkHelp, PolFactorLambdas) {
 }
 
 TEST(TestLinkHelp, SigmaModification) {
-  // Test function that multiplies value with output of functions
+  /** Test function that returns lambda for value multiplied with output of 
+      functions.
+  **/
   std::vector<std::function<double()>> alpha_fcts {
     [](){return 2.5;},
     [](){return 3.0;}
   };
   double val = 2.0;
-  
-  double mod_val = LinkHelp::get_modified_sigma(val,alpha_fcts);
+
+  auto mod_val = LinkHelp::get_modified_sigma(val,alpha_fcts);
   // 2.5 * 3 * 2 = 15
-  ASSERT_EQ(Num::equal_to_eps(mod_val, 15.0, 1e-9), true)
-    << "Got " << mod_val << " expected " << 15.0;
+  ASSERT_EQ(Num::equal_to_eps(mod_val(), 15.0, 1e-9), true)
+    << "Got " << mod_val() << " expected " << 15.0;
 }
+//------------------------------------------------------------------------------

--- a/source/tests/Connect/test_LinkHelp.cpp
+++ b/source/tests/Connect/test_LinkHelp.cpp
@@ -1,0 +1,63 @@
+#include <Connect/LinkHelp.h>
+#include <CppUtils/Num.h>
+#include <Fit/FitPar.h>
+#include <GlobalVar/Chiral.h>
+
+#include <gtest/gtest.h>
+
+#include <functional>
+#include <string>
+
+using namespace PREW::Connect;
+using namespace PREW::CppUtils;
+using namespace PREW::Fit;
+using namespace PREW::GlobalVar;
+
+//------------------------------------------------------------------------------
+// Tests for helper functions for prediction linking
+
+TEST(TestLinkHelp, PolFactorLambdas) {
+  // Test function that returns lambda for polarisation factor
+  ParVec pars {
+    {"ePol", -1.0, 0.0}, // e- Pol.: -100%
+    {"pPol", +1.0, 0.0}, // e+ Pol.: +100%
+  };
+  std::pair<std::string,std::string> pol_pair {"ePol","pPol"};
+  
+  auto factor_LR = LinkHelp::get_polfactor_lambda(Chiral::eLpR,pol_pair,&pars);
+  auto factor_RL = LinkHelp::get_polfactor_lambda(Chiral::eRpL,pol_pair,&pars);
+  auto factor_LL = LinkHelp::get_polfactor_lambda(Chiral::eLpL,pol_pair,&pars);
+  auto factor_RR = LinkHelp::get_polfactor_lambda(Chiral::eRpR,pol_pair,&pars);
+  
+  ASSERT_EQ(factor_LR(),1);
+  ASSERT_EQ(factor_RL(),0);
+  ASSERT_EQ(factor_LL(),0);
+  ASSERT_EQ(factor_RR(),0);
+  
+  // Change polarisations and check that factors changed
+  pars[0].m_val_mod = -0.8; // e- Pol.: -80%
+  pars[1].m_val_mod = +0.3; // e+ Pol.: +30%
+  
+  ASSERT_EQ(Num::equal_to_eps(factor_LR(), 0.585, 1e-9), true)
+    << "Got " << factor_LR() << " expected " << 0.585;
+  ASSERT_EQ(Num::equal_to_eps(factor_RL(), 0.035, 1e-9), true)
+    << "Got " << factor_RL() << " expected " << 0.035;
+  ASSERT_EQ(Num::equal_to_eps(factor_LL(), 0.315, 1e-9), true)
+    << "Got " << factor_LL() << " expected " << 0.315;
+  ASSERT_EQ(Num::equal_to_eps(factor_RR(), 0.065, 1e-9), true)
+    << "Got " << factor_RR() << " expected " << 0.065;
+}
+
+TEST(TestLinkHelp, SigmaModification) {
+  // Test function that multiplies value with output of functions
+  std::vector<std::function<double()>> alpha_fcts {
+    [](){return 2.5;},
+    [](){return 3.0;}
+  };
+  double val = 2.0;
+  
+  double mod_val = LinkHelp::get_modified_sigma(val,alpha_fcts);
+  // 2.5 * 3 * 2 = 15
+  ASSERT_EQ(Num::equal_to_eps(mod_val, 15.0, 1e-9), true)
+    << "Got " << mod_val << " expected " << 15.0;
+}

--- a/source/tests/Connect/test_Linker.cpp
+++ b/source/tests/Connect/test_Linker.cpp
@@ -1,0 +1,194 @@
+#include <Connect/Linker.h>
+#include <CppUtils/Num.h>
+#include <CppUtils/Vec.h>
+#include <Data/CoefDistr.h>
+#include <Data/FnctLink.h>
+#include <Fit/FitPar.h>
+
+#include <gtest/gtest.h>
+
+#include <functional>
+#include <string>
+
+using namespace PREW::Connect;
+using namespace PREW::CppUtils;
+using namespace PREW::Data;
+using namespace PREW::Fit;
+
+//------------------------------------------------------------------------------
+// Tests for Linker class that creates connected and easily callable functions
+
+TEST(TestLinker, GaussianTest) {
+  // Test that linker can give out correct functions that gives values for a 
+  // gaussian at a given x value, gaussian values must change when gaussian 
+  // parameters are changed.
+  
+  // --- Prediction data:
+  // x values to look at (1D)
+  Vec::Matrix2D<double> bin_centers {
+    {{-1}},{{0}},{{1}},{{1.5}},{{2}}
+  };
+  // No coefficients for now
+  CoefDistrVec coefs {};
+  // Fit parameters (which will change during minimization in other stage)
+  ParVec pars = {
+    FitPar("A", 1, 0),    // Amplitude
+    FitPar("mu", 0, 0),   // Mean
+    FitPar("sigma", 1, 0) // Width
+  };
+  
+  // --- Instructions on how to connect to prediction:
+  FnctLinkVec fnct_links {
+    {"Gaussian1D", // Only one function here: Gaussian
+      {"A","mu","sigma"}, // Parameter map
+      {} // Coefficient map
+    }
+  };
+  
+  // --- Get functions from linker which are linked to parameters
+  Linker linker = Linker(fnct_links, bin_centers, coefs);
+  
+  auto gaussian_bin0 = linker.get_bonded_fnct_at_bin("Gaussian1D",0,&pars);
+  auto gaussian_bin1 = linker.get_bonded_fnct_at_bin("Gaussian1D",1,&pars);
+  auto gaussian_bin2 = linker.get_bonded_fnct_at_bin("Gaussian1D",2,&pars);
+  auto gaussian_bin3 = linker.get_bonded_fnct_at_bin("Gaussian1D",3,&pars);
+  auto gaussian_bin4 = linker.get_bonded_fnct_at_bin("Gaussian1D",4,&pars);
+  
+  // --- Check (changing) function output
+  // Looked up exact expected values in WolframAlpha -> compare
+  ASSERT_EQ(Num::equal_to_eps(gaussian_bin0(), 0.2419707245, 1e-9), true)
+    << "Got " << gaussian_bin0() << " expected " << 0.2419707245;
+  ASSERT_EQ(Num::equal_to_eps(gaussian_bin1(), 0.3989422804, 1e-9), true)
+    << "Got " << gaussian_bin1() << " expected " << 0.3989422804;
+  ASSERT_EQ(Num::equal_to_eps(gaussian_bin2(), 0.2419707245, 1e-9), true)
+    << "Got " << gaussian_bin2() << " expected " << 0.2419707245;
+  ASSERT_EQ(Num::equal_to_eps(gaussian_bin3(), 0.1295175957, 1e-9), true)
+    << "Got " << gaussian_bin3() << " expected " << 0.1295175957;
+  ASSERT_EQ(Num::equal_to_eps(gaussian_bin4(), 0.0539909665, 1e-9), true)
+    << "Got " << gaussian_bin4() << " expected " << 0.0539909665;
+    
+  // Changing parameters (same bin coordinates!)
+  pars[0].m_val_mod = 2; // Amplitude
+  pars[1].m_val_mod = 1.5; // Mean
+  pars[2].m_val_mod = 0.5; // Width
+  
+  // Did function outputs change?
+  // -> If so succesfully established link between parameters and functions
+  ASSERT_EQ(Num::equal_to_eps(gaussian_bin1(), 0.0177273936, 1e-9), true)
+    << "Got " << gaussian_bin1() << " expected " << 0.0177273936;
+  ASSERT_EQ(Num::equal_to_eps(gaussian_bin2(), 0.9678828981, 1e-9), true)
+    << "Got " << gaussian_bin2() << " expected " << 0.9678828981;
+  ASSERT_EQ(Num::equal_to_eps(gaussian_bin3(), 1.5957691216, 1e-9), true)
+    << "Got " << gaussian_bin3() << " expected " << 1.5957691216;
+}
+
+TEST(TestLinker, GaussianManyValuesTest) {
+  // Same as GaussianTest but only testing that it's not a problem to create
+  // loads of functions
+  
+  // --- Prediction data:
+  // x values to look at (1D)
+  Vec::Matrix2D<double> bin_centers {};
+  for (double center=-20; center<20; center+=0.001) {
+    bin_centers.push_back({center});
+  } // 40/0.01 = 40000 bins -> as many functions
+  // No coefficients for now
+  CoefDistrVec coefs {};
+  // Fit parameters (which will change during minimization in other stage)
+  ParVec pars = {
+    FitPar("A", 1, 0),    // Amplitude
+    FitPar("mu", 0, 0),   // Mean
+    FitPar("sigma", 1, 0) // Width
+  };
+  
+  // --- Instructions on how to connect to prediction:
+  FnctLinkVec fnct_links {
+    {"Gaussian1D", // Only one function here: Gaussian
+      {"A","mu","sigma"}, // Parameter map
+      {} // Coefficient map
+    }
+  };
+  
+  // --- Get functions from linker which are linked to parameters
+  Linker linker = Linker(fnct_links, bin_centers, coefs);
+  
+  // Get all bin functions
+  std::vector<std::function<double()>> gaussian_at_bins {};
+  for (int bin=0; bin<bin_centers.size(); bin++) {
+    gaussian_at_bins.push_back(
+      linker.get_bonded_fnct_at_bin("Gaussian1D",bin,&pars)
+    );
+  }
+  
+  // --- Check output (only roughly)
+  // Check that no zero value occured
+  bool found_zero_val = false;
+  for (const auto & gaussian_at_bin: gaussian_at_bins ) {
+    if (gaussian_at_bin() == 0) {
+      found_zero_val = true;
+      break;
+    }
+  }
+  ASSERT_EQ(found_zero_val, false);
+  
+  // Modify amplitude to zero and check again, now all should be zero
+  pars[0].m_val_mod = 0;
+  bool found_nonzero_val = false;
+  for (const auto & gaussian_at_bin: gaussian_at_bins ) {
+    if (gaussian_at_bin() != 0) {
+      found_nonzero_val = true;
+      break;
+    }
+  }
+  ASSERT_EQ(found_nonzero_val, false);
+}
+
+
+TEST(TestLinker, MultiFunctionTest) {
+  // Test that it works for having two different functions whose parameters 
+  // are connected
+  
+  // --- Prediction data:
+  // x values to look at (1D)
+  Vec::Matrix2D<double> bin_centers { {1.0} }; // Just one bin at x=1
+  // No coefficients for now
+  CoefDistrVec coefs {};
+  
+  // Fit parameters (which will change during minimization in other stage)
+  ParVec pars = {
+    FitPar("P1", 1, 0),   // Parameter will be in both parameterisations!
+    FitPar("mu", 1, 0),   // Gaussian Mean
+    FitPar("sigma", 1, 0),// Gaussian Width
+    FitPar("P2", 2, 0),   // Linear polynomial parameter
+    FitPar("P3", 3, 0)    // Quadratic polynomial parameter
+  };
+  
+  // --- Instructions on how to connect to prediction:
+  FnctLinkVec fnct_links {
+    {"Gaussian1D", {"P1","mu","sigma"}, {}},
+    {"Quadratic1DPolynomial", {"P1","P2","P3"}, {}} // Notice P1 overlap!
+  };
+  
+  // --- Get functions from linker which are linked to parameters
+  Linker linker = Linker(fnct_links, bin_centers, coefs);
+  
+  auto gaussian_bin = 
+    linker.get_bonded_fnct_at_bin("Gaussian1D",0,&pars);
+  auto quadratic_bin = 
+    linker.get_bonded_fnct_at_bin("Quadratic1DPolynomial",0,&pars);
+
+  // --- Check for expected output
+  ASSERT_EQ(Num::equal_to_eps(gaussian_bin(), 0.3989422804, 1e-9), true)
+    << "Got " << gaussian_bin() << " expected " << 0.3989422804;
+  ASSERT_EQ(Num::equal_to_eps(quadratic_bin(), 6.0, 1e-9), true) // 1+2+3=6
+    << "Got " << quadratic_bin() << " expected " << 6;
+    
+  // Change one(!) parameter -> Both outputs should change!
+  pars[0].m_val_mod = 2; // -> Amplite/Offset doubled
+  
+  ASSERT_EQ(Num::equal_to_eps(gaussian_bin(), 2.0*0.3989422804, 1e-9), true)
+    << "Got " << gaussian_bin() << " expected " << 2.0*0.3989422804;
+  ASSERT_EQ(Num::equal_to_eps(quadratic_bin(), 7.0, 1e-9), true) // 2+2+3=6
+    << "Got " << quadratic_bin() << " expected " << 2;
+}
+//------------------------------------------------------------------------------

--- a/source/tests/Connect/test_Linker.cpp
+++ b/source/tests/Connect/test_Linker.cpp
@@ -171,11 +171,11 @@ TEST(TestLinker, MultiFunctionTest) {
   
   // --- Get functions from linker which are linked to parameters
   Linker linker = Linker(fnct_links, bin_centers, coefs);
+  auto all_bin_fncts = linker.get_all_bonded_fncts_at_bin(0,&pars);
+  ASSERT_EQ( all_bin_fncts.size(), 2 );
   
-  auto gaussian_bin = 
-    linker.get_bonded_fnct_at_bin("Gaussian1D",0,&pars);
-  auto quadratic_bin = 
-    linker.get_bonded_fnct_at_bin("Quadratic1DPolynomial",0,&pars);
+  auto gaussian_bin  = all_bin_fncts.at(0);
+  auto quadratic_bin = all_bin_fncts.at(1);
 
   // --- Check for expected output
   ASSERT_EQ(Num::equal_to_eps(gaussian_bin(), 0.3989422804, 1e-9), true)

--- a/source/tests/CppUtils/test_Vec.cpp
+++ b/source/tests/CppUtils/test_Vec.cpp
@@ -1,0 +1,46 @@
+#include <CppUtils/Vec.h>
+
+#include <gtest/gtest.h>
+
+#include <vector>
+#include <string>
+
+using namespace PREW::CppUtils;
+
+//------------------------------------------------------------------------------
+// Tests for vector helpers
+
+TEST(TestVec, SubVecFinding) {
+  /** Test finding of a subvector using a condition function.
+  **/
+  // Original vector 
+  std::vector<double> vec = {-1, 234234, 0, -45, 0.333, -3, -1e9};
+  
+  // Condition function: Only negative values
+  auto condition = [](double val) { return val < 0; };
+  
+  // Negative value vector
+  std::vector<double> subvec = Vec::subvec_by_condition(vec, condition);
+  
+  // Expectation:
+  std::vector<double> expected = {-1, -45, -3, -1e9};
+  
+  ASSERT_EQ(subvec, expected);
+}
+
+TEST(TestVec, ElementFinding) {
+  /** Test finding of an element using a condition function.
+  **/
+  // Original vector 
+  std::vector<std::string> vec = {"a", "A", "abc", "0sd9"};
+  
+  // Condition function: string must be three letters long
+  auto condition = [](std::string str) { return str.size() == 3; };
+  
+  // Corresponding element
+  std::string element = Vec::element_by_condition(vec, condition);
+  
+  ASSERT_EQ(element, "abc");
+}
+
+//------------------------------------------------------------------------------

--- a/source/tests/Data/test_DistrInfo.cpp
+++ b/source/tests/Data/test_DistrInfo.cpp
@@ -1,0 +1,26 @@
+#include <gtest/gtest.h>
+
+#include <Data/DistrInfo.h>
+
+using namespace PREW::Data;
+
+//------------------------------------------------------------------------------
+// Tests for DistrInfo class
+
+TEST(TestData, EqualOperator) {
+  /** Test that equal operator works properly.
+  **/
+  DistrInfo info1 {"a", "LR", 100};
+  DistrInfo info1_clone {"a", "LR", 100};
+  DistrInfo info2 {"b", "LR", 100};
+  DistrInfo info3 {"a", "LL", 100};
+  DistrInfo info4 {"a", "LR", 200};
+  
+  
+  ASSERT_EQ(info1 == info1_clone, true);
+  ASSERT_EQ(info1 == info2, false);
+  ASSERT_EQ(info1 == info3, false);
+  ASSERT_EQ(info1 == info4, false);
+}
+
+//------------------------------------------------------------------------------

--- a/source/tests/Data/test_DistrUtils.cpp
+++ b/source/tests/Data/test_DistrUtils.cpp
@@ -1,0 +1,83 @@
+#include <Data/DistrInfo.h>
+#include <Data/DiffDistr.h>
+#include <Data/DistrUtils.h>
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+using namespace PREW::Data;
+
+//------------------------------------------------------------------------------
+// Tests for distribution helper functions
+
+TEST(TestDistrUtils, SubVecEnergyName) {
+  // Test if distributions are correctly extracted by their name and energy
+  std::string good_name = "d1";
+  DistrInfo info_good1 {good_name,"LR",200};
+  DistrInfo info_good2 {good_name,"RL",200};
+  DistrInfo info_bad1 {"d2","LR",200};
+  DistrInfo info_bad2 {good_name,"LR",400};
+  
+  DiffDistrVec vec {
+    {info_good1, {}, {}},
+    {info_good1, {}, {}},
+    {info_good2, {}, {}},
+    {info_bad1, {}, {}},
+    {info_bad2, {}, {}},
+  };
+  
+  // Should extract exactly 3 distributions named "d1" with energy 200
+  ASSERT_EQ(DistrUtils::subvec_energy_and_name(vec,200,good_name).size(), 3);
+}
+
+TEST(TestDistrUtils, SubVecEnergy) {
+  // Test if distributions are correctly extracted by energy
+  DistrInfo info_good1 {"d1","LR",200};
+  DistrInfo info_good2 {"d2","RL",200};
+  DistrInfo info_bad1 {"d1","LR",400};
+  
+  DiffDistrVec vec {
+    {info_good1, {}, {}},
+    {info_good2, {}, {}},
+    {info_bad1, {}, {}},
+  };
+  
+  // Should extract exactly 2 distributions with energy 200
+  ASSERT_EQ(DistrUtils::subvec_energy(vec,200).size(), 2);
+}
+
+TEST(TestDistrUtils, SubVecPol) {
+  // Test if distributions are correctly extracted by polarisation
+  DistrInfo info_good1 {"d1","LR",200};
+  DistrInfo info_good2 {"d2","LR",400};
+  DistrInfo info_bad1 {"d1","RL",200};
+  
+  DiffDistrVec vec {
+    {info_good1, {}, {}},
+    {info_good2, {}, {}},
+    {info_bad1, {}, {}},
+  };
+  
+  // Should extract exactly 2 distributions with polarisation "LR"
+  std::string good_pol = "LR";
+  ASSERT_EQ(DistrUtils::subvec_pol(vec,good_pol).size(), 2);
+}
+
+TEST(TestDistrUtils, ElementPol) {
+  // Test if element with given polarisation is correctly extracted
+  std::string pol_good = "LR";
+  std::string pol_bad = "RL";
+  DistrInfo info_good {"d1",pol_good,200};
+  DistrInfo info_bad {"d1",pol_bad,200};
+  
+  DiffDistrVec vec {
+    {info_good, {}, {}},
+    {info_bad, {}, {}},
+    {info_bad, {}, {}},
+  };
+  
+  ASSERT_EQ(DistrUtils::element_pol(vec,pol_good).m_info,info_good);
+}
+
+//------------------------------------------------------------------------------

--- a/source/tests/Fit/test_FitBin.cpp
+++ b/source/tests/Fit/test_FitBin.cpp
@@ -3,9 +3,15 @@
 
 using namespace PREW::Fit;
 
+TEST(TestFitbin, TrivialConstructor) {
+  FitBin fb {};
+  ASSERT_EQ(fb.get_val_mst(), 0);
+  ASSERT_EQ(fb.get_val_unc(), 0);
+}
+  
 TEST(TestFitbin, ReturnsCorrectVals) {
-  FitBin fb1 (0.0035, 200.0, std::function<double()> {});
-  FitBin fb2 (-1110.022, 0.0, std::function<double()> {});
+  FitBin fb1 (0.0035, 200.0);
+  FitBin fb2 (-1110.022, 0.0);
   ASSERT_EQ(fb1.get_val_mst(), 0.0035);
   ASSERT_EQ(fb1.get_val_unc(), 200.0);
   ASSERT_EQ(fb2.get_val_mst(), -1110.022);

--- a/source/tests/Fit/test_FitBin.cpp
+++ b/source/tests/Fit/test_FitBin.cpp
@@ -35,3 +35,16 @@ TEST(TestFitbin, CorrectChangedPrediction) {
   x = -3.5;
   ASSERT_EQ(fb.get_val_prd(), -3.5);
 }
+
+TEST(TestFitbin, PredictionFunctionSetting) {
+  // Test that setting of a prediction function works properly
+  FitBin fb {}; // Empty bin, no fit function
+  auto fct_1 = [](){return 2.5;};
+  auto fct_2 = [](){return -4000.0;};
+
+  fb.set_prd_fct(fct_1);
+  ASSERT_EQ(fb.get_val_prd(), 2.5);
+
+  fb.set_prd_fct(fct_2);
+  ASSERT_EQ(fb.get_val_prd(), -4000.0);
+}

--- a/source/tests/Fit/test_FitPar.cpp
+++ b/source/tests/Fit/test_FitPar.cpp
@@ -1,10 +1,13 @@
-#include <gtest/gtest.h>
 #include <Fit/FitPar.h>
+#include <CppUtils/Num.h>
+
+#include <gtest/gtest.h>
 
 #include <string>  
 #include <sstream>   
 
 using namespace PREW::Fit;
+using namespace PREW::CppUtils;
 
 TEST(TestFitPar, ReturnsCorrectIni) {
   FitPar fp1 ("fp1", 0.00055, 0.01);
@@ -46,6 +49,22 @@ TEST(TestFitPar, EqualOperator) {
   ASSERT_EQ(fp1 == fp1, true);
   ASSERT_EQ(fp1 == fp2, false);
   ASSERT_EQ(fp1 == fp1_copy, true);
+}
+
+TEST(TestFitPar, CopyAssignmentOperator) {
+  FitPar fp1 ("fp1", 0, 0.01);
+  FitPar fp2 ("fp2", 1, 0.05);
+  FitPar fp2_copy = fp2;
+  ASSERT_EQ(fp1 == fp2, false); // Compares only name string
+  ASSERT_EQ(fp2 == fp2_copy, true);
+  ASSERT_EQ(Num::equal_to_eps(fp2.get_val_ini(), fp2_copy.get_val_ini()), true);
+  ASSERT_EQ(Num::equal_to_eps(fp2.get_unc_ini(), fp2_copy.get_unc_ini()), true);
+  
+  fp2 = fp1; // Overwrite fp1
+  ASSERT_EQ(fp1 == fp2, true);
+  ASSERT_EQ(fp2 == fp2_copy, false);
+  ASSERT_EQ(Num::equal_to_eps(fp2.get_val_ini(), fp2_copy.get_val_ini()), false);
+  ASSERT_EQ(Num::equal_to_eps(fp2.get_unc_ini(), fp2_copy.get_unc_ini()), false);
 }
 
 TEST(TestFitPar, ConstrCalcWithoutConstr) {

--- a/source/tests/Fit/test_ParConstrGauss.cpp
+++ b/source/tests/Fit/test_ParConstrGauss.cpp
@@ -1,24 +1,55 @@
-#include <gtest/gtest.h>
 #include <Fit/ParConstrGauss.h>
+#include <CppUtils/Num.h>
+
+#include <gtest/gtest.h>
 
 #include <math.h>
 
+using namespace PREW::CppUtils;
 using namespace PREW::Fit;
 
 TEST(TestParConstrGauss, DefaultConstructor) {
   ParConstrGauss constr {}; // Gaussian constr. around 0 with unc. of 1
-  EXPECT_EQ(constr.calc_chisq(0), 0);
+  ASSERT_EQ(constr.get_val(), 0);
+  ASSERT_EQ(constr.get_unc(), 1);
+  ASSERT_EQ(constr.calc_chisq(0), 0);
 }
 
 TEST(TestParConstrGauss, SimpleChiSq) {
   ParConstrGauss constr (0.0, 1.0); // Gaussian constr. around 0 with unc. of 1
-  EXPECT_EQ(constr.calc_chisq(0), 0);
-  EXPECT_EQ(constr.calc_chisq(1), 1);
-  EXPECT_EQ(constr.calc_chisq(2), 4);
+  ASSERT_EQ(constr.get_val(), 0);
+  ASSERT_EQ(constr.get_unc(), 1);
+  ASSERT_EQ(constr.calc_chisq(0), 0);
+  ASSERT_EQ(constr.calc_chisq(1), 1);
+  ASSERT_EQ(constr.calc_chisq(2), 4);
 }
 
 TEST(TestParConstrGauss, PrecisionChiSq) {
   // Test that precision is held over orders of magnitude
   ParConstrGauss constr (200000.05, 50000.05);
-  EXPECT_EQ( fabs(constr.calc_chisq(250000.1) - 1.0) < 0.00001, true);
+  ASSERT_EQ(Num::equal_to_eps(constr.calc_chisq(250000.1), 1.0, 0.00001), true);
+}
+
+TEST(TestParConstrGauss, EqualOperator) {
+  ParConstrGauss constr1 (0, 0.01);
+  ParConstrGauss constr2 (0, 0.01);
+  ParConstrGauss constr3 (1, 0.01);
+  ParConstrGauss constr4 (0, 0.05);
+  
+  ASSERT_EQ(constr1 == constr1, true);
+  ASSERT_EQ(constr1 == constr2, true);
+  ASSERT_EQ(constr1 == constr3, false);
+  ASSERT_EQ(constr1 == constr4, false);
+}
+
+TEST(TestParConstrGauss, CopyAssignmentOperator) {
+  ParConstrGauss constr_1 (0, 0.01);
+  ParConstrGauss constr_2 (1, 0.05);
+  ParConstrGauss constr_2_copy = constr_2;
+  ASSERT_EQ(constr_1 == constr_2, false);
+  ASSERT_EQ(constr_2 == constr_2_copy, true);
+  
+  constr_2 = constr_1; // Overwrite constr_1
+  ASSERT_EQ(constr_1 == constr_2, true);
+  ASSERT_EQ(constr_2 == constr_2_copy, false);
 }

--- a/source/tests/Fncts/test_Physics.cpp
+++ b/source/tests/Fncts/test_Physics.cpp
@@ -1,0 +1,35 @@
+#include <CppUtils/Num.h>
+#include <Fncts/Physics.h>
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+using namespace PREW::CppUtils;
+using namespace PREW::Fncts;
+
+//------------------------------------------------------------------------------
+// Check that polynomial functions are correctly implemented
+
+TEST(TestPhysics, PolarisationFactor) {
+  // Test the polarisation factor function.
+  std::vector<double> c {
+    +1, // e- chirality = R
+    -1  // e+ chirality = L
+  };
+  std::vector<double> p_vals {  
+    -0.2, // e- beam polarisation
+    0.6   // e+ beam polarisation
+  };
+  std::vector<double*> p_ptrs {};
+  for (double & p: p_vals) { p_ptrs.push_back(&p); }
+  
+  // (1+(+1)*(-0.2)) * (1+(-1)*(0.6)) / 4.0 = 0.08
+  ASSERT_EQ( 
+    Num::equal_to_eps( Physics::polarisation_factor({},c,p_ptrs), 0.08, 1e-9), 
+    true 
+  ) << "Expected " << 0.08 
+    << " got " << Physics::polarisation_factor({},c,p_ptrs);
+}
+
+//------------------------------------------------------------------------------

--- a/source/tests/Fncts/test_Polynomial.cpp
+++ b/source/tests/Fncts/test_Polynomial.cpp
@@ -1,0 +1,45 @@
+#include <CppUtils/Num.h>
+#include <Fncts/Polynomial.h>
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+using namespace PREW::CppUtils;
+using namespace PREW::Fncts;
+
+//------------------------------------------------------------------------------
+// Check that polynomial functions are correctly implemented
+
+TEST(TestPolynomial, Gaussian1D) {
+  std::vector<double> c {};
+  std::vector<double> p_vals {  1.0, // Offset
+                                2.0, // Linear parameter
+                                0.5  // Quadratic parameter
+                              };
+  std::vector<double*> p_ptrs {};
+  for (double & p: p_vals) { p_ptrs.push_back(&p); }
+
+  ASSERT_EQ( 
+    Num::equal_to_eps( Polynomial::quadratic_1D( {-1.} ,c,p_ptrs), -0.5, 1e-9), 
+    true 
+  ) << "Expected " << -0.5 
+    << " got " << Polynomial::quadratic_1D({-1.},c,p_ptrs);
+  ASSERT_EQ(
+    Num::equal_to_eps( Polynomial::quadratic_1D( {0.0} ,c,p_ptrs), 1.0, 1e-9),
+    true
+  ) << "Expected " << 1.0 
+    << " got " << Polynomial::quadratic_1D({0.0},c,p_ptrs);
+  ASSERT_EQ(
+    Num::equal_to_eps( Polynomial::quadratic_1D( {1.0} ,c,p_ptrs), 3.5, 1e-9),
+    true
+  ) << "Expected " << 3.5 
+    << " got " << Polynomial::quadratic_1D({1.0},c,p_ptrs);
+  ASSERT_EQ(
+    Num::equal_to_eps( Polynomial::quadratic_1D( {1.5} ,c,p_ptrs), 5.125, 1e-9),
+    true
+  ) << "Expected " << 5.125 
+    << " got " << Polynomial::quadratic_1D({1.5},c,p_ptrs);
+}
+
+//------------------------------------------------------------------------------

--- a/source/tests/Fncts/test_Statistic.cpp
+++ b/source/tests/Fncts/test_Statistic.cpp
@@ -1,0 +1,45 @@
+#include <CppUtils/Num.h>
+#include <Fncts/Statistic.h>
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+using namespace PREW::CppUtils;
+using namespace PREW::Fncts;
+
+//------------------------------------------------------------------------------
+// Check that statistical functions are correctly implemented
+
+TEST(TestStatistic, Gaussian1D) {
+  std::vector<double> c {};
+  std::vector<double> p_vals {  1.5, // Amplitude
+                                0.5, // Mean
+                                2.0  // Sigma
+                              };
+  std::vector<double*> p_ptrs {};
+  for (double & p: p_vals) { p_ptrs.push_back(&p); }
+
+  ASSERT_EQ( 
+    Num::equal_to_eps( Statistic::gaussian_1D( {-1.} ,c,p_ptrs), 0.225853, 1e-5), 
+    true 
+  ) << "Expected " << 0.225853 
+    << " got " << Statistic::gaussian_1D({-1.},c,p_ptrs);
+  ASSERT_EQ(
+    Num::equal_to_eps( Statistic::gaussian_1D( {0.0} ,c,p_ptrs), 0.290001, 1e-5),
+    true
+  ) << "Expected " << 0.290001 
+    << " got " << Statistic::gaussian_1D({0.0},c,p_ptrs);
+  ASSERT_EQ(
+    Num::equal_to_eps( Statistic::gaussian_1D( {1.0} ,c,p_ptrs), 0.290001, 1e-5),
+    true
+  ) << "Expected " << 0.290001 
+    << " got " << Statistic::gaussian_1D({1.0},c,p_ptrs);
+  ASSERT_EQ(
+    Num::equal_to_eps( Statistic::gaussian_1D( {1.5} ,c,p_ptrs), 0.264049, 1e-5),
+    true
+  ) << "Expected " << 0.264049 
+    << " got " << Statistic::gaussian_1D({1.5},c,p_ptrs);
+}
+
+//------------------------------------------------------------------------------

--- a/source/tests/Input/test_DataReader.cpp
+++ b/source/tests/Input/test_DataReader.cpp
@@ -32,8 +32,14 @@ TEST(TestDataReader, TestRKFileReading) {
   reader.read_file();
   auto measured_distributions = reader.get_meas_distrs();
   auto predicted_distributions = reader.get_pred_distrs();
-  ASSERT_EQ(measured_distributions.size(), 0); // RK files don't contain measurement
-  ASSERT_EQ(predicted_distributions.size(), 24);
+  auto prediction_coefficients = reader.get_coef_distrs();
+  
+  // RK files don't contain measurements
+  ASSERT_EQ(measured_distributions.size(), 0); 
+  // Contains distributions for 6 process with each 4 chiralities
+  ASSERT_EQ(predicted_distributions.size(), 6*4);
+  // Contains for 3 processes (*4) each 9 coefficients 
+  ASSERT_EQ(prediction_coefficients.size(), 3*4*9);
 }
 
 //------------------------------------------------------------------------------

--- a/source/tests/Input/test_DataReader.cpp
+++ b/source/tests/Input/test_DataReader.cpp
@@ -23,15 +23,17 @@ TEST(TestDataReader, ExceptionOnWrongInputStyle) {
   ASSERT_THROW(reader.read_file(), std::invalid_argument);
 }
 
-TEST(TestDataReader, TestFileReading) {
-  /** Check that reading of example file runs and gives right number of 
+TEST(TestDataReader, TestRKFileReading) {
+  /** Check that reading of an RK example file runs and gives right number of 
       distributions.
   **/
   InfoRKFile i {"../testdata/RK_examplefile_500_250_2018_04_03.root", 250};
   DataReader reader(&i, "RK");
   reader.read_file();
-  auto distributions = reader.get_distributions();
-  ASSERT_EQ(distributions.size(), 24);
+  auto measured_distributions = reader.get_meas_distrs();
+  auto predicted_distributions = reader.get_pred_distrs();
+  ASSERT_EQ(measured_distributions.size(), 0); // RK files don't contain measurement
+  ASSERT_EQ(predicted_distributions.size(), 24);
 }
 
 //------------------------------------------------------------------------------

--- a/source/tests/Input/test_DataReader.cpp
+++ b/source/tests/Input/test_DataReader.cpp
@@ -11,15 +11,15 @@ using namespace PREW::Input;
 TEST(TestDataReader, ExceptionOnWrongFile) {
   /** Check that exception is thrown on invalid file path.
   **/
-  InfoRKFile i {"./obviously_wrong_file_path.root", 250};
-  ASSERT_THROW(DataReader(&i, "RK"), std::invalid_argument);
+  InfoRKFile i {"./obviously_wrong_file_path.root", "RK", 250};
+  ASSERT_THROW(DataReader(static_cast<InputInfo*>(&i)), std::invalid_argument);
 }
 
 TEST(TestDataReader, ExceptionOnWrongInputStyle) {
   /** Check that exception is thrown if file exists but input style not known.
   **/
-  InfoRKFile i {"../testdata/RK_examplefile_500_250_2018_04_03.root", 250};
-  DataReader reader(&i, "cheese");
+  InfoRKFile i {"../testdata/RK_examplefile_500_250_2018_04_03.root", "cheese", 250};
+  DataReader reader(&i);
   ASSERT_THROW(reader.read_file(), std::invalid_argument);
 }
 
@@ -27,8 +27,8 @@ TEST(TestDataReader, TestRKFileReading) {
   /** Check that reading of an RK example file runs and gives right number of 
       distributions.
   **/
-  InfoRKFile i {"../testdata/RK_examplefile_500_250_2018_04_03.root", 250};
-  DataReader reader(&i, "RK");
+  InfoRKFile i {"../testdata/RK_examplefile_500_250_2018_04_03.root", "RK", 250};
+  DataReader reader(&i);
   reader.read_file();
   auto measured_distributions = reader.get_meas_distrs();
   auto predicted_distributions = reader.get_pred_distrs();

--- a/source/tests/Input/test_InputInfo.cpp
+++ b/source/tests/Input/test_InputInfo.cpp
@@ -11,12 +11,13 @@ TEST(TestInputInfo, CastCheck) {
   /** Check if an InfoRKFile object (subclass of InputInfo) can be successfully
       cast to an InputInfo object and back.
   **/
-  InfoRKFile i {"a", 250};
+  InfoRKFile i {"a", "b", 250};
   InfoRKFile *i_ptr = &i;
   InputInfo *a_ptr = i_ptr;
   InfoRKFile *c_ptr = static_cast<InfoRKFile*>(a_ptr);
   
   ASSERT_EQ(c_ptr->m_file_path, "a"); 
+  ASSERT_EQ(c_ptr->m_input_style, "b"); 
   ASSERT_EQ(c_ptr->m_energy, 250); 
 }
 

--- a/source/tests/Input/test_Reading.cpp
+++ b/source/tests/Input/test_Reading.cpp
@@ -1,0 +1,23 @@
+#include <gtest/gtest.h>
+
+#include <Input/Reading.h>
+#include <Input/InputInfo.h>
+
+using namespace PREW::Input;
+
+//------------------------------------------------------------------------------
+// Tests specific for functions in Reading
+
+TEST(TestReading, RKReadingExceptionOnWrongInfoType) {
+  /** Check that exception is thrown on invalid file path.
+  **/
+  InputInfo i {"../testdata/RK_examplefile_500_250_2018_04_03.root"}; // path OK
+  Data::PredDistrVec *dummy_ptr_1; 
+  Data::CoefDistrVec *dummy_ptr_2;
+  ASSERT_THROW(
+    Reading::read_RK_file(&i, dummy_ptr_1, dummy_ptr_2), 
+    std::invalid_argument 
+  );
+}
+
+//------------------------------------------------------------------------------

--- a/source/tests/Input/test_Reading.cpp
+++ b/source/tests/Input/test_Reading.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <Data/CoefDistr.h>
+#include <Data/PredDistr.h>
 #include <Input/Reading.h>
 #include <Input/InputInfo.h>
 
@@ -9,11 +11,12 @@ using namespace PREW::Input;
 // Tests specific for functions in Reading
 
 TEST(TestReading, RKReadingExceptionOnWrongInfoType) {
-  /** Check that exception is thrown on invalid file path.
+  /** Check that exception is thrown on invalid input class.
   **/
-  InputInfo i {"../testdata/RK_examplefile_500_250_2018_04_03.root"}; // path OK
-  Data::PredDistrVec *dummy_ptr_1; 
-  Data::CoefDistrVec *dummy_ptr_2;
+  // Parameters of class ok but class wrong (would need to be InfoRKFile)
+  InputInfo i {"../testdata/RK_examplefile_500_250_2018_04_03.root", "RK"}; 
+  PREW::Data::PredDistrVec *dummy_ptr_1; 
+  PREW::Data::CoefDistrVec *dummy_ptr_2;
   ASSERT_THROW(
     Reading::read_RK_file(&i, dummy_ptr_1, dummy_ptr_2), 
     std::invalid_argument 

--- a/source/tests/ToyMeas/test_ToyGenerator.cpp
+++ b/source/tests/ToyMeas/test_ToyGenerator.cpp
@@ -1,0 +1,77 @@
+#include <Connect/DataConnector.h>
+#include <CppUtils/Num.h>
+#include <CppUtils/Vec.h>
+#include <Data/CoefDistr.h>
+#include <Data/PredDistr.h>
+#include <Data/PredLink.h>
+#include <Data/PolLink.h>
+#include <Fit/FitPar.h>
+#include <GlobalVar/Chiral.h>
+#include <ToyMeas/ToyGenerator.h>
+
+#include <gtest/gtest.h>
+#include "spdlog/spdlog.h"
+
+using namespace PREW::Connect;
+using namespace PREW::CppUtils;
+using namespace PREW::Data;
+using namespace PREW::Fit;
+using namespace PREW::GlobalVar;
+using namespace PREW::ToyMeas;
+
+//------------------------------------------------------------------------------
+// Check that statistical functions are correctly implemented
+
+TEST(TestToyGenerator, SimpleConstructor) {
+  /** Copy-paste of DataConnector test with slightly varied values,
+      tests that bin predicitions are in the end properly transformed into bin
+      content of a faked differential distribution.
+  **/
+  DistrInfo info_pol {"test", "e-p+", 500};
+  DistrInfo info_LR {"test", Chiral::eLpR, 500};
+  DistrInfo info_RL {"test", Chiral::eRpL, 500};
+  DistrInfo info_LL {"test", Chiral::eLpL, 500};
+  DistrInfo info_RR {"test", Chiral::eRpR, 500};
+  Vec::Matrix2D<double> bin_centers = {{0}, {1}};
+  PredDistrVec pred_distrs { 
+    { info_LR, bin_centers, {1}, {0} },
+    { info_RL, bin_centers, {1}, {0} },
+    { info_LL, bin_centers, {1}, {0} },
+    { info_RR, bin_centers, {1}, {0} },
+  };
+  ParVec input_pars { 
+    {"A_pol", 2, 0},
+    {"A_LR", 1, 0},
+    {"mu", 0, 0},
+    {"sigma", 0.5, 0},
+    {"ePol", -0.60, 0},
+    {"pPol", +0.20, 0}
+  };
+  CoefDistrVec coef_distrs {};
+  PredLinkVec  pred_links {
+    { info_LR, { {"Gaussian1D", {"A_LR", "mu", "sigma"}} }, {} },
+    { info_RL, {}, {} },
+    { info_LL, {}, {} },
+    { info_RR, {}, {} },
+    { info_pol, { {"Gaussian1D", {"A_pol", "mu", "sigma"}} }, {} }
+  };
+  PolLinkVec   pol_links {
+    {500, { {"e-p+", {"ePol", "pPol"}} }}
+  };
+  
+  DataConnector connector {pred_distrs,coef_distrs,pred_links,pol_links};
+  
+  ToyGenerator test_gen = ToyGenerator( connector, input_pars );
+                
+  // Do I get correctly sized distributions?
+  auto expected_distrs = test_gen.get_expected_distrs(500);
+  ASSERT_EQ(expected_distrs.size(), 1);
+  ASSERT_EQ(expected_distrs[0].m_distribution.size(), 2);
+  
+  // Is the distribution content accurate?
+  double bin0_content = expected_distrs[0].m_distribution[0].get_val_mst();
+  ASSERT_EQ( Num::equal_to_eps(bin0_content, 1.44095492471, 1e-9), true )
+    << "Expected " << 1.44095492471 << " got " << bin0_content;
+}
+
+//------------------------------------------------------------------------------


### PR DESCRIPTION
- Add new DistrInfo class that stores the info which uniquely identifies a distribution.
- Adjust Distr1D to implement DistrInfo.
- Adjust file reading to write correctly to Distr1D.
- Rename Distr1D to DiffDistr because distribution can be in multidimensional space.
- Add new PredDistr struct to store predicted distributions.
- Change output of reader of RK style file to PredDistr instead of DiffDistr.
- Split distribution in DataReader into prediction and measurement (both may or may not be read depending on file type).
- Adjust DataReader test to new PredDistr struct.
- Fix missing include for string in DistrInfo.
- Add missing include in PredDistr.
- Add namespace to CppUtils that contains string helpers.
- Add string helper function that can split a string according to a delimiter.
- Add new CoefDistr container class that hold one (named) coefficient for each bin of a distribution (per process / chirality).
- Add member variable to DataReader that contains vector of coefficients to be extracted from file (and add get function).
- Change Reading function that reads RK style file to also read coefficients.
- Adjust DataReader to proper usage of RK file reading.
- In test of DataReader check if coefficients are correctly read.
- Add testing for Reading namespace, test if RK style reading throw exception when expected.
- Store the input type of the file directly in InputInfo.
- Simplify DataReader constructor due to input type now being stored in InputInfo.
- Adapt DataReader functionality to new input type storage.
- Adjust all Input tests to new usage of DataReader and new initialisation of InputInfo.
- Make get functionalities of DataReader return const references.
- In PredDistr save two distributions: signal cross section and background cross section.
- Adjust reading of RK file, only hold signal cross section prediction.
- Correct the documentation in DiffDistr, explain why only number of events can be used.
- Add namespace GlobalVar in which static const variables can be defined which are only used by variable name throughout PrEW.
- Define PrEW-global string variables for generator level chiral combinations.
- Implement usage of common const static string variables in reading of RK style file.
- Fix missing vector include in CoefDistr.
- Add equal operator and copy assignment operator for ParConstrGauss.
- Add tests for equal and copy assignment operators of ParConstrGauss.
- Change ParConstrGauss tests so that they use assert instead of expect.
- Add default copy assignment operator for FitPar.
- Add test for copy assignment of FitPar.
- Save beam energy as int and not double (framework is not made for precise beam energy studies).
- Remove process name from DistrInfo and everywhere else and instead only use distribution name (Process concept turned out unnecessary).
- Add helper namespace for maps which (for now) only consists of aliases.
- Add helper functions for vectors that can extract subvectors or an element using a condition.
- Add tests for vector extraction helper functions.
- Add default values for FitBin constructor and add test to see they get correctly set.
- Use passing by const ref in ChiSqMinimizer class.
- Add equal operator to DistrInfo and add test for equal operator.
- Adjust FitContainer to proper file style.
- Add namespace for polynomial parameterisation functions.
- Add simple quadratic 1D parameterisation function, including test.
- Add namespace for parameterisation functions which come from statistics.
- Add gaussian 1D parametrisation function, including test.
- Add namespace for C++ helpers related to std::function, now only including an alias.
- Add mapping of string to parameterisation function.
- Add struct that contains information on how a function is to be connected (i.e. which parameters and coefficients to use).
- Add function linker class that can (given the according instructions and value vectors for the bins) give a function which corresponds to a parameterisation and is bonded to the fit parameters.
- Add tests for linker class.
- Fix mistake in comile script docu.
- Add new storage struct PredLink which stores the function links for a given distributions.
- Add new PolLink storage class that stores how (for a given energy) each polarisation configuration links to different individual polarisations.
- Add reader function to Linker that allows getting all bonded parameterization functions for a bin.
- Add new namespace LinkHelp that help connecting the prediction functions.
- Add tests for new LinkHelp functions.
- Add new namespace in Fncts that is dedicated to physics-motivated functions and include a function for polarisation factors.
- Add polarisation factor function to function map.
- Add test for polarisation factor function.
- Add set function in FitBin to set the prediction function after construction.
- Add test for FitBin prediction function setting.
- Add DistrUtils namespace with helper functions for distribution vectors.
- Add functions that can extract sub-vectors or and element of a distribution by a given kind of information (e.g. energy).
- Add tests for DistrUtils functions.
- In LinkHelp make sigma modification function return a std::function instead of a double.
- Adjust LinkHelp tests to changed sigma modification output.
- Add DataConnector class that stores all of the prediction information and can properly link a given differential distribution.
- Add tests for the DataConnnector class.
- Add ToyGenerator class that can give toy measurements (differential distributions containing the fluctuated prediction as bin content).
- Add test for ToyGenerator.

