### PR TITLE
Correct polarisation handling

### DIFF
--- a/source/prew/include/Connect/LinkHelp.h
+++ b/source/prew/include/Connect/LinkHelp.h
@@ -1,6 +1,7 @@
 #ifndef LIB_LINKHELP_H
 #define LIB_LINKHELP_H 1
 
+#include <Data/PolLink.h>
 #include <Fit/FitPar.h>
 
 #include <functional>
@@ -15,8 +16,8 @@ namespace LinkHelp {
   **/
   
   std::function<double()> get_polfactor_lambda(
-    const std::string                         & chirality, 
-    const std::pair<std::string, std::string> & pol_pair, 
+    const std::string   & chirality, 
+    const Data::PolLink & pol_link, 
     Fit::ParVec *pars
   );
   

--- a/source/prew/include/Data/PolLink.h
+++ b/source/prew/include/Data/PolLink.h
@@ -1,21 +1,45 @@
 #ifndef LIB_POLLINK_H
 #define LIB_POLLINK_H 1
 
-#include <CppUtils/Map.h>
+#include <string>
+#include <vector>
 
 namespace PREW {
 namespace Data {
 
-  struct PolLink {
-    /** Class that stores which polarisation configuration couples which 
-        individual beam polarisations together.
+  class PolLink {
+    /** Class that stores information about how to couple beam polarisations
+        for a given polarisation configuration at a given energy.
     **/
     
-    int m_energy {}; // This depends on the energy!
+    int m_energy {}; // Depends on the energy
+    std::string m_pol_config {}; // Name of polarisation configuration
     
-    // Map from polarisation setup to individual beam polarisation names
-    // => Rule: First electron polarisation, second positron polarisation
-    CppUtils::Map::StrToStrPairMap m_config_pol_links {};
+    // Name of single beam polarisation variables
+    std::string m_eM_pol {}; 
+    std::string m_eP_pol {};  
+    
+    // Signs of sign beam polarisation variables ("+" or "-")
+    std::string m_eM_sgn {};
+    std::string m_eP_sgn {};
+    
+    public:
+      // Constructors
+      PolLink() = default;
+      PolLink(
+        int energy, 
+        std::string pol_config, 
+        std::string eM_pol,     std::string eP_pol, 
+        std::string eM_sgn="+", std::string eP_sgn="+"
+      );
+      
+      int get_energy() const;
+      std::string get_pol_config() const;
+      std::string get_eM_pol() const;
+      std::string get_eP_pol() const;
+      
+      double get_eM_sgn_factor() const;
+      double get_eP_sgn_factor() const;
   };
 
   using PolLinkVec = std::vector<PolLink>;

--- a/source/prew/src/Connect/DataConnector.cpp
+++ b/source/prew/src/Connect/DataConnector.cpp
@@ -94,13 +94,12 @@ void DataConnector::fill_bins(
   CppUtils::Vec::Matrix2D<double> bin_centers = diff_distr.m_bin_centers;
   
   // Find polarisation link for this energy
-  auto energy_condition = 
-    [energy](const Data::PolLink& link) {return link.m_energy==energy;};
+  auto energy_pol_condition = 
+    [energy,pol_config](const Data::PolLink& link) {
+      return (link.get_energy()==energy) && (link.get_pol_config()==pol_config);
+    };
   Data::PolLink pol_link = 
-    CppUtils::Vec::element_by_condition( m_pol_links, energy_condition );
-
-  // Individual beam polarisations
-  auto pol_pair = pol_link.m_config_pol_links.at(pol_config);
+    CppUtils::Vec::element_by_condition(m_pol_links, energy_pol_condition);
 
   // Find corresponding predicted distributions, links and coefficients
   Data::PredDistrVec predictions  = 
@@ -169,13 +168,13 @@ void DataConnector::fill_bins(
 
   // --- Get polarisation factor alpha functions -------------------------------
   auto pol_factor_LR = 
-    LinkHelp::get_polfactor_lambda(GlobalVar::Chiral::eLpR, pol_pair, pars);
+    LinkHelp::get_polfactor_lambda(GlobalVar::Chiral::eLpR, pol_link, pars);
   auto pol_factor_RL = 
-    LinkHelp::get_polfactor_lambda(GlobalVar::Chiral::eRpL, pol_pair, pars);
+    LinkHelp::get_polfactor_lambda(GlobalVar::Chiral::eRpL, pol_link, pars);
   auto pol_factor_LL = 
-    LinkHelp::get_polfactor_lambda(GlobalVar::Chiral::eLpL, pol_pair, pars);
+    LinkHelp::get_polfactor_lambda(GlobalVar::Chiral::eLpL, pol_link, pars);
   auto pol_factor_RR = 
-    LinkHelp::get_polfactor_lambda(GlobalVar::Chiral::eRpR, pol_pair, pars);
+    LinkHelp::get_polfactor_lambda(GlobalVar::Chiral::eRpR, pol_link, pars);
   // ---------------------------------------------------------------------------
 
   // Set the prediction of each distribution

--- a/source/prew/src/Data/PolLink.cpp
+++ b/source/prew/src/Data/PolLink.cpp
@@ -1,0 +1,61 @@
+#include <Data/PolLink.h>
+
+#include <stdexcept>
+#include <string>
+
+namespace PREW {
+namespace Data {
+
+//------------------------------------------------------------------------------
+// Constructors
+
+PolLink::PolLink(
+  int energy, 
+  std::string pol_config, 
+  std::string eM_pol, std::string eP_pol, 
+  std::string eM_sgn, std::string eP_sgn
+) : 
+  m_energy(energy),
+  m_pol_config(pol_config),
+  m_eM_pol(eM_pol),
+  m_eP_pol(eP_pol),
+  m_eM_sgn(eM_sgn),
+  m_eP_sgn(eP_sgn)
+{
+  /** Construtor checks polarisation signs are valid.
+      Sign can be:
+        "+" => Take polarisation variable as is
+        "-" => Take negative of polarisation variable
+  **/
+  if ( (m_eM_sgn != "+") && (m_eM_sgn != "-") ) {
+    throw std::invalid_argument("Invalid e- pol. sign for : " + m_eM_pol);
+  } 
+  if ( (m_eP_sgn != "+") && (m_eP_sgn != "-") ) {
+    throw std::invalid_argument("Invalid e+ pol. sign for : " + m_eP_pol);
+  } 
+}
+
+//------------------------------------------------------------------------------
+// Get functions
+
+int PolLink::get_energy() const { return m_energy; }
+std::string PolLink::get_pol_config() const { return m_pol_config; }
+std::string PolLink::get_eM_pol() const { return m_eM_pol; }
+std::string PolLink::get_eP_pol() const { return m_eP_pol; }
+
+double PolLink::get_eM_sgn_factor() const {
+  /** Get the factor (+1 or -1) associated with the e- polarisation sign.
+  **/
+  return (m_eM_sgn == "-") ? -1.0 : 1.0;
+}
+
+double PolLink::get_eP_sgn_factor() const {
+  /** Get the factor (+1 or -1) associated with the e+ polarisation sign.
+  **/
+  return (m_eP_sgn == "-") ? -1.0 : 1.0;
+}
+
+//------------------------------------------------------------------------------
+
+}
+}

--- a/source/prew/src/Fit/ChiSqMinimizer.cpp
+++ b/source/prew/src/Fit/ChiSqMinimizer.cpp
@@ -113,7 +113,6 @@ void ChiSqMinimizer::update_result() {
   
   if (m_result != FitResult()) {
     spdlog::debug("FitResult not empty, will be overwritten.");
-    m_result = {};
   }
   
   unsigned int n_pars = m_container->m_fit_pars.size();

--- a/source/prew/src/Fncts/Physics.cpp
+++ b/source/prew/src/Fncts/Physics.cpp
@@ -11,14 +11,19 @@ double Physics::polarisation_factor (
   const std::vector<double*> &p
 ) {
   /** Calculate polarisation factor for given chirality (handled by 
-      coeffficients) and polarisations (handled by parameters).
+      coeffficients) and polarisations (amplitude handled by parameters, 
+      sign handled by coefficients).
       Coefficients: c[0] - electron chirality (-1 = L , +1 = R)
                     c[1] - positron chirality (-1 = L , +1 = R)
-      Parameters: p[0] - electron beam polarisation
-                  p[1] - positron beam polarisation
+                    c[2] - electron beam polarisation sign
+                    c[3] - positron beam polarisation sign
+      Parameters: p[0] - electron beam polarisation amplitude
+                  p[1] - positron beam polarisation amplitude
   **/
   
-  return 0.25 * ( 1 + c[0] * (*(p[0])) ) * ( 1 + c[1] * (*(p[1])) );
+  return 0.25 * 
+        ( 1 + c[0] * c[2] * (*(p[0])) ) * 
+        ( 1 + c[1] * c[3] * (*(p[1])) );
 }
 
 }

--- a/source/prew/src/ToyMeas/ToyGenerator.cpp
+++ b/source/prew/src/ToyMeas/ToyGenerator.cpp
@@ -42,12 +42,15 @@ ToyGenerator::ToyGenerator(
     // Find polarisation link for this energy 
     // => which polarisations exist?
     auto energy_condition = 
-      [energy](const Data::PolLink& link) {return link.m_energy==energy;};
-    Data::PolLink pol_link = 
-      CppUtils::Vec::element_by_condition( m_connector.get_pol_links(), energy_condition );
+      [energy](const Data::PolLink& link) {return link.get_energy()==energy;};
+    Data::PolLinkVec pol_links = 
+      CppUtils::Vec::subvec_by_condition( 
+        m_connector.get_pol_links(), energy_condition 
+      );
       
     // Find all available polarisations at energy from polarisation link
-    for (const auto& [pol_config, pol_pair]: pol_link.m_config_pol_links) {
+    for (const auto& pol_link: pol_links) {
+      std::string pol_config = pol_link.get_pol_config();
       pol_configs_per_energies[energy].insert(pol_config);
     }
   }

--- a/source/tests/Connect/test_DataConnector.cpp
+++ b/source/tests/Connect/test_DataConnector.cpp
@@ -42,7 +42,9 @@ TEST(TestDataConnector, ReadFunctions) {
   PredLinkVec  pred_links {
     { info_LR, { {"Gaussian1D", {"A_LR", "mu", "sigma"}} }, {} },
   };
-  PolLinkVec   pol_links { {500, { {"e-p+", {"ePol", "pPol"}} }} };
+  PolLinkVec pol_links { 
+    PolLink(500, "e-p+", "ePol", "pPol", "-", "+")
+   };
   
   DataConnector connector {pred_distrs,coef_distrs,pred_links,pol_links};
 
@@ -75,8 +77,8 @@ TEST(TestDataConnector, DistrFilling) {
     {"A_LR", 1, 0},
     {"mu", 0, 0},
     {"sigma", 0.5, 0},
-    {"ePol", -0.80, 0},
-    {"pPol", +0.30, 0}
+    {"ePol", 0.80, 0},
+    {"pPol", 0.30, 0}
   };
   CoefDistrVec coef_distrs {};
   PredLinkVec  pred_links {
@@ -87,7 +89,7 @@ TEST(TestDataConnector, DistrFilling) {
     { info_pol, { {"Gaussian1D", {"A_pol", "mu", "sigma"}} }, {} }
   };
   PolLinkVec   pol_links {
-    {500, { {"e-p+", {"ePol", "pPol"}} }}
+    PolLink(500, "e-p+", "ePol", "pPol", "-", "+")
   };
   
   // Connector has task to connect all of that

--- a/source/tests/Connect/test_LinkHelp.cpp
+++ b/source/tests/Connect/test_LinkHelp.cpp
@@ -1,5 +1,6 @@
 #include <Connect/LinkHelp.h>
 #include <CppUtils/Num.h>
+#include <Data/PolLink.h>
 #include <Fit/FitPar.h>
 #include <GlobalVar/Chiral.h>
 
@@ -10,6 +11,7 @@
 
 using namespace PREW::Connect;
 using namespace PREW::CppUtils;
+using namespace PREW::Data;
 using namespace PREW::Fit;
 using namespace PREW::GlobalVar;
 
@@ -19,15 +21,15 @@ using namespace PREW::GlobalVar;
 TEST(TestLinkHelp, PolFactorLambdas) {
   // Test function that returns lambda for polarisation factor
   ParVec pars {
-    {"ePol", -1.0, 0.0}, // e- Pol.: -100%
-    {"pPol", +1.0, 0.0}, // e+ Pol.: +100%
+    {"ePol", 1.0, 0.0}, // e- Pol.: 100% -> Sign in PolLink (-)
+    {"pPol", 1.0, 0.0}, // e+ Pol.: 100% -> Sign in PolLink (+)
   };
-  std::pair<std::string,std::string> pol_pair {"ePol","pPol"};
+  PolLink pol_link {500, "test", "ePol", "pPol", "-", "+"};
   
-  auto factor_LR = LinkHelp::get_polfactor_lambda(Chiral::eLpR,pol_pair,&pars);
-  auto factor_RL = LinkHelp::get_polfactor_lambda(Chiral::eRpL,pol_pair,&pars);
-  auto factor_LL = LinkHelp::get_polfactor_lambda(Chiral::eLpL,pol_pair,&pars);
-  auto factor_RR = LinkHelp::get_polfactor_lambda(Chiral::eRpR,pol_pair,&pars);
+  auto factor_LR = LinkHelp::get_polfactor_lambda(Chiral::eLpR,pol_link,&pars);
+  auto factor_RL = LinkHelp::get_polfactor_lambda(Chiral::eRpL,pol_link,&pars);
+  auto factor_LL = LinkHelp::get_polfactor_lambda(Chiral::eLpL,pol_link,&pars);
+  auto factor_RR = LinkHelp::get_polfactor_lambda(Chiral::eRpR,pol_link,&pars);
   
   ASSERT_EQ(factor_LR(),1);
   ASSERT_EQ(factor_RL(),0);
@@ -35,8 +37,8 @@ TEST(TestLinkHelp, PolFactorLambdas) {
   ASSERT_EQ(factor_RR(),0);
   
   // Change polarisations and check that factors changed
-  pars[0].m_val_mod = -0.8; // e- Pol.: -80%
-  pars[1].m_val_mod = +0.3; // e+ Pol.: +30%
+  pars[0].m_val_mod = 0.8; // e- Pol.: -80%
+  pars[1].m_val_mod = 0.3; // e+ Pol.: +30%
   
   ASSERT_EQ(Num::equal_to_eps(factor_LR(), 0.585, 1e-9), true)
     << "Got " << factor_LR() << " expected " << 0.585;

--- a/source/tests/Data/test_PolLink.cpp
+++ b/source/tests/Data/test_PolLink.cpp
@@ -1,0 +1,34 @@
+#include <Data/PolLink.h>
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+using namespace PREW::Data;
+
+//------------------------------------------------------------------------------
+// Tests for polarisation instruction class
+
+TEST(TestPolLink, DefaultConstructor) {
+  PolLink pol_link {};
+  
+  ASSERT_EQ(pol_link.get_energy(),0);
+  ASSERT_STREQ(pol_link.get_pol_config().c_str(),"");
+  ASSERT_STREQ(pol_link.get_eM_pol().c_str(),"");
+  ASSERT_STREQ(pol_link.get_eP_pol().c_str(),"");
+  ASSERT_EQ(pol_link.get_eM_sgn_factor(),+1.0);
+  ASSERT_EQ(pol_link.get_eP_sgn_factor(),+1.0);
+}
+
+TEST(TestPolLink, SimpleConstructor) {
+  PolLink pol_link {500,"e-p-","ePol","pPol","-","-"};
+  
+  ASSERT_EQ(pol_link.get_energy(),500);
+  ASSERT_STREQ(pol_link.get_pol_config().c_str(),"e-p-");
+  ASSERT_STREQ(pol_link.get_eM_pol().c_str(),"ePol");
+  ASSERT_STREQ(pol_link.get_eP_pol().c_str(),"pPol");
+  ASSERT_EQ(pol_link.get_eM_sgn_factor(),-1.0);
+  ASSERT_EQ(pol_link.get_eP_sgn_factor(),-1.0);
+}
+
+//------------------------------------------------------------------------------

--- a/source/tests/Fncts/test_Physics.cpp
+++ b/source/tests/Fncts/test_Physics.cpp
@@ -15,11 +15,13 @@ TEST(TestPhysics, PolarisationFactor) {
   // Test the polarisation factor function.
   std::vector<double> c {
     +1, // e- chirality = R
-    -1  // e+ chirality = L
+    -1, // e+ chirality = L
+    -1, // e- beam polarisation sign
+    +1  // e- beam polarisation sign
   };
   std::vector<double> p_vals {  
-    -0.2, // e- beam polarisation
-    0.6   // e+ beam polarisation
+    0.2, // e- beam polarisation amplitude
+    0.6  // e+ beam polarisation amplitude
   };
   std::vector<double*> p_ptrs {};
   for (double & p: p_vals) { p_ptrs.push_back(&p); }

--- a/source/tests/ToyMeas/test_ToyGenerator.cpp
+++ b/source/tests/ToyMeas/test_ToyGenerator.cpp
@@ -44,8 +44,8 @@ TEST(TestToyGenerator, SimpleConstructor) {
     {"A_LR", 1, 0},
     {"mu", 0, 0},
     {"sigma", 0.5, 0},
-    {"ePol", -0.60, 0},
-    {"pPol", +0.20, 0}
+    {"ePol", 0.60, 0},
+    {"pPol", 0.20, 0}
   };
   CoefDistrVec coef_distrs {};
   PredLinkVec  pred_links {
@@ -56,7 +56,7 @@ TEST(TestToyGenerator, SimpleConstructor) {
     { info_pol, { {"Gaussian1D", {"A_pol", "mu", "sigma"}} }, {} }
   };
   PolLinkVec   pol_links {
-    {500, { {"e-p+", {"ePol", "pPol"}} }}
+    PolLink(500, "e-p+", "ePol", "pPol", "-", "+")
   };
   
   DataConnector connector {pred_distrs,coef_distrs,pred_links,pol_links};


### PR DESCRIPTION
- Remove wrong resetting of FitResult in ChiSqMinimizer that removed FitPar names.
- Modify PolLink so that it is class instead of struct and that it separates the polarisation amplitude (as parameter) and the polarisation sign (as constant).
- Add test for modified PolLink class.
- Adjust polarisation factor function and its test to new separation of polarisation amplitude and polarisation sign.
- Adjust LinkHelp function that gives polarisation factor lambda to use modified PolLink class with separated polarisation sign and amplitude.
- Adjust LinkHelp test to modified polarisation factor lambda function.
- Adjust DataConnector and its test to separation of polarisation amplitude and polarisation sign using PolLink class.
- Adjust ToyGenerator and its test to separation of polarisation amplitude and polarisation sign using PolLink class.