### PR TITLE
Add toy fluctuations

### DIFF
--- a/source/prew/include/CppUtils/Rnd.h
+++ b/source/prew/include/CppUtils/Rnd.h
@@ -1,0 +1,23 @@
+#ifndef LIB_RND_H
+#define LIB_RND_H 1
+
+#include <random>
+
+namespace PREW { 
+namespace CppUtils {
+  
+namespace Rnd {
+  /** Namespace for random number generation / fluctuation.
+  **/
+  
+  // Global random number generator to avoid duplication of random numbers
+  static std::random_device rnd_device;
+  static std::mt19937 rnd_gen(rnd_device());
+  
+  int poisson_fluctuate(double mean);
+}
+  
+}
+}
+
+#endif

--- a/source/prew/include/Fit/FitBin.h
+++ b/source/prew/include/Fit/FitBin.h
@@ -26,6 +26,8 @@ namespace Fit {
         std::function<double()> prd_fct=NULL
       );
       
+      void set_val_mst(double val_mst);
+      void set_val_unc(double val_unc);
       void set_prd_fct(std::function<double()> prd_fct); // Set prediction fct.
       
       double get_val_mst() const; // Get measured value

--- a/source/prew/include/ToyMeas/Flct.h
+++ b/source/prew/include/ToyMeas/Flct.h
@@ -1,0 +1,21 @@
+#ifndef LIB_FLCT_H
+#define LIB_FLCT_H 1
+
+#include <CppUtils/Num.h>
+#include <CppUtils/Rnd.h>
+#include <Fit/FitBin.h>
+
+namespace PREW { 
+namespace ToyMeas {
+  
+namespace Flct {
+  /** Namespace for functions to fluctuate bins and distributions.
+  **/
+  
+  void poisson_fluctuate(Fit::FitBin &bin);
+}
+  
+}
+}
+
+#endif

--- a/source/prew/include/ToyMeas/ToyGenerator.h
+++ b/source/prew/include/ToyMeas/ToyGenerator.h
@@ -44,6 +44,7 @@ namespace ToyMeas {
       );
       
       Data::DiffDistrVec get_expected_distrs ( int energy ) const;
+      Data::DiffDistrVec get_fluctuated_distrs ( int energy ) const;
   };
 }
 }

--- a/source/prew/src/CppUtils/Rnd.cpp
+++ b/source/prew/src/CppUtils/Rnd.cpp
@@ -1,0 +1,23 @@
+#include <CppUtils/Rnd.h>
+
+#include <stdexcept>
+
+namespace PREW {
+namespace CppUtils {
+  
+//------------------------------------------------------------------------------
+
+int Rnd::poisson_fluctuate(double mean) {
+  /** Produce a random number from poisson distribution with given mean.
+  **/
+  if ( mean<0 ) { 
+    throw std::invalid_argument("Poisson not defined for negativ mean!");
+  }
+  std::poisson_distribution<int> distribution(mean);
+  return distribution(Rnd::rnd_gen);
+}
+
+//------------------------------------------------------------------------------
+
+}
+}

--- a/source/prew/src/Fit/FitBin.cpp
+++ b/source/prew/src/Fit/FitBin.cpp
@@ -12,6 +12,8 @@ FitBin::FitBin(double val_mst, double val_unc, std::function<double()> prd_fct) 
 //------------------------------------------------------------------------------
 // set functions
 
+void FitBin::set_val_mst(double val_mst) { m_val_mst = val_mst; }
+void FitBin::set_val_unc(double val_unc) { m_val_unc = val_unc; }
 void FitBin::set_prd_fct(std::function<double()> prd_fct) {m_prd_fct = prd_fct;}
 
 //------------------------------------------------------------------------------

--- a/source/prew/src/ToyMeas/Flct.cpp
+++ b/source/prew/src/ToyMeas/Flct.cpp
@@ -1,0 +1,28 @@
+#include <CppUtils/Num.h>
+#include <CppUtils/Rnd.h>
+#include <Fit/FitBin.h>
+#include <ToyMeas/Flct.h>
+
+#include <cmath>
+
+namespace PREW {
+namespace ToyMeas {
+  
+//------------------------------------------------------------------------------
+
+void Flct::poisson_fluctuate(Fit::FitBin &bin) {
+  /** Poisson fluctuate the measured value in the bin and adjust the 
+      uncertainty.
+  **/
+  bin.set_val_mst( CppUtils::Rnd::poisson_fluctuate(bin.get_val_mst()) );
+  
+  // If content zero keep previous uncertainty, else poisson uncertainty
+  if ( ! CppUtils::Num::equal_to_eps(bin.get_val_mst(),0.0) ) { 
+    bin.set_val_unc( std::sqrt(bin.get_val_mst()) );
+  }
+}
+
+//------------------------------------------------------------------------------
+
+}
+}

--- a/source/prew/src/ToyMeas/ToyGenerator.cpp
+++ b/source/prew/src/ToyMeas/ToyGenerator.cpp
@@ -4,6 +4,7 @@
 #include <Data/DistrInfo.h>
 #include <Data/DistrUtils.h>
 #include <GlobalVar/Chiral.h>
+#include <ToyMeas/Flct.h>
 #include <ToyMeas/ToyGenerator.h>
 
 #include "spdlog/spdlog.h"
@@ -134,6 +135,21 @@ Data::DiffDistrVec ToyGenerator::get_expected_distrs ( int energy ) const {
   }
   
   return output_distrs;
+}
+
+Data::DiffDistrVec ToyGenerator::get_fluctuated_distrs ( int energy ) const {
+  /** Get poisson fluctuated versions of the expected distributions at the given
+      energy.
+  **/
+  Data::DiffDistrVec distrs = this->get_expected_distrs(energy);
+  
+  // Fluctuate each bin with a Poisson distribution on its value and adjust unc.
+  for (auto & distr: distrs) {
+    for (auto & bin: distr.m_distribution) {
+      Flct::poisson_fluctuate(bin);
+    }
+  }
+  return distrs;
 }
 
 //------------------------------------------------------------------------------

--- a/source/tests/CppUtils/test_Rnd.cpp
+++ b/source/tests/CppUtils/test_Rnd.cpp
@@ -1,0 +1,26 @@
+#include <gtest/gtest.h>
+#include <CppUtils/Num.h>
+#include <CppUtils/Rnd.h>
+
+using namespace PREW::CppUtils;
+
+//------------------------------------------------------------------------------
+// Tests for random number generation
+
+TEST(TestRnd, PoissonRange) {
+  ASSERT_THROW(Rnd::poisson_fluctuate(-1.0), std::invalid_argument);
+}
+
+TEST(TestRnd, PoissonMeanTests) {
+  std::vector<double> means {0.5, 2.5, 15.0};
+  int n_vals = 10000;
+  for (const auto & mean: means){
+    double sum = 0;
+    for (int i=0; i<n_vals; i++) { sum += Rnd::poisson_fluctuate(mean); }
+    double result_mean = sum / double(n_vals);
+    ASSERT_EQ(Num::equal_to_eps(result_mean, mean, 5e-2*mean), true)
+      << "Expected mean: " << mean << " , got: " << result_mean;
+  }
+}
+
+//------------------------------------------------------------------------------

--- a/source/tests/Fit/test_FitBin.cpp
+++ b/source/tests/Fit/test_FitBin.cpp
@@ -18,6 +18,18 @@ TEST(TestFitbin, ReturnsCorrectVals) {
   ASSERT_EQ(fb2.get_val_unc(), 0.0);
 }
 
+TEST(TestFitbin, ValSetting) {
+  FitBin fb {};
+  fb.set_val_mst(2.4);
+  fb.set_val_unc(0.3);
+  ASSERT_EQ(fb.get_val_mst(), 2.4);
+  ASSERT_EQ(fb.get_val_unc(), 0.3);
+  fb.set_val_mst(-7.0);
+  fb.set_val_unc(10.5);
+  ASSERT_EQ(fb.get_val_mst(), -7.0);
+  ASSERT_EQ(fb.get_val_unc(), 10.5);
+}
+
 TEST(TestFitbin, CorrectTrivialPrediction) {
   std::function<double()> trivial_prd = []() { return 2.1; };
   FitBin fb (0, 0, trivial_prd);

--- a/source/tests/ToyMeas/test_Flct.cpp
+++ b/source/tests/ToyMeas/test_Flct.cpp
@@ -1,0 +1,25 @@
+#include <CppUtils/Num.h>
+#include <Fit/FitBin.h>
+#include <ToyMeas/Flct.h>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+using namespace PREW::CppUtils;
+using namespace PREW::Fit;
+using namespace PREW::ToyMeas;
+
+//------------------------------------------------------------------------------
+// Test random fluctuation of FitBin values
+
+TEST(TestFlct, BinGetsFluctuated) {
+  FitBin bin(20.5,0.5);
+  Flct::poisson_fluctuate(bin);
+  
+  ASSERT_EQ( Num::equal_to_eps(fmod(bin.get_val_mst(), 1.0), 0.0), true )
+    << "Poisson fluctuation gave non-integer: " << bin.get_val_mst();
+  ASSERT_EQ( (bin.get_val_unc() != 0.5), true );
+}
+
+//------------------------------------------------------------------------------

--- a/source/tests/ToyMeas/test_ToyGenerator.cpp
+++ b/source/tests/ToyMeas/test_ToyGenerator.cpp
@@ -69,9 +69,17 @@ TEST(TestToyGenerator, SimpleConstructor) {
   ASSERT_EQ(expected_distrs[0].m_distribution.size(), 2);
   
   // Is the distribution content accurate?
+  double bin0_expected = 1.44095492471;
   double bin0_content = expected_distrs[0].m_distribution[0].get_val_mst();
-  ASSERT_EQ( Num::equal_to_eps(bin0_content, 1.44095492471, 1e-9), true )
-    << "Expected " << 1.44095492471 << " got " << bin0_content;
+  ASSERT_EQ( Num::equal_to_eps(bin0_content, bin0_expected, 1e-9), true )
+    << "Expected " << bin0_expected << " got " << bin0_content;
+    
+  // Do toy fluctuations work?
+  auto fluctuated_distrs = test_gen.get_fluctuated_distrs(500);
+  ASSERT_EQ(fluctuated_distrs.size(), 1);
+  ASSERT_EQ(fluctuated_distrs[0].m_distribution.size(), 2);
+  double bin0_fluctuated = fluctuated_distrs[0].m_distribution[0].get_val_mst();
+  ASSERT_EQ( Num::equal_to_eps(bin0_fluctuated, bin0_expected, 1e-9), false );
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
- Add new namespace for random number generation including a global random number generator.
- Add function to get poisson fluctuated number.
- Add test for poisson fluctuation.
- Add functions to FitBin that allow setting of measurement value and uncertainty.
- Add test for FitBin value setting.
- Add namespace and function to fluctuate a FitBin.
- Add test for FitBin fluctuation.
- In ToyGenerator add function that returns fluctuation prediction as a toy measurement.
- Include testing of toy fluctuation in ToyGenerator test.