### PR TITLE
Make usable

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -29,3 +29,4 @@
  ```sh
  cd macros && chmod u+x compile.sh && ./compile.sh && cd ..
  ```
+ The compilation can also be done in multithreaded mode using `./compile.sh --jobs=N_jobs`.

--- a/macros/compile.sh
+++ b/macros/compile.sh
@@ -3,22 +3,54 @@
 # -------------------------------------------------#
 # Bash script for compiling the processor of the
 # analysis.
-# To be run simply by using: ./compile.sh [-rebuild]
+# To be run simply by using: ./compile.sh [--rebuild] [--jobs=n_jobs]
 # Be sure a modern software is sourced! (E.g. sourcing load_env.sh)
 # -------------------------------------------------#
 
-if [[  $# > 1 ]]  ; then
-	echo "usage: ./compile.sh [-rebuild]"
-	exit
-fi
-
 # -------------------------------------------------#
-# Optional input parameter:
-# Should everything be rebuild? 
-# (-> will delete content of build folder)
-if [ $# == 1 ]; then
-  REBUILD=true
-fi
+# Check for input arguments to script
+
+# Default parameters
+REBUILD=false
+N_JOBS=1
+
+# Help message
+USAGE="Usage: ./compile.sh [-h/--help/-H] [--rebuild] [--jobs=n_jobs]"
+
+for i in "$@"
+do
+case $i in
+  --jobs=*)
+    N_JOBS="${i#*=}"
+    echo "Main compilation will use ${N_JOBS} jobs."
+    shift # past argument=value
+  ;;
+  --rebuild)
+    REBUILD=true
+    shift
+  ;;
+  -h|--help|-H)
+    echo ""
+    echo "Macro to compile the PrEW source code"
+    echo "${USAGE}"
+    echo ""
+    echo "Arguments:"
+    echo "  -h/--help/-H  : Help information (this)." 
+    echo "  --rebuild     : Delete previous build folder for clean rebuild." 
+    echo "  --jobs=n_jobs : Set a number of cores to use in compilation." 
+    echo ""
+    exit
+  ;;
+  *)
+    # unknown option
+    echo ""
+    echo "Unknown argument: ${1}"
+    echo "${USAGE}"
+    echo ""
+    exit
+  ;;
+esac
+done
 
 # -------------------------------------------------#
 # Check if necessary directories are in place
@@ -29,7 +61,7 @@ home_folder=${dir}/..
 if [ -d "${home_folder}"/build  ] ; then
 	echo "Already have  --build-- directory to compile"
   # If requested remove build folder content
-  if [ ${REBUILD} ]; then 
+  if [ "${REBUILD}" = true ]; then 
     echo "Rebuild requested => Recreating build directory"
     rm -r "${home_folder}"/build
     mkdir "${home_folder}"/build
@@ -51,7 +83,7 @@ cmake ..
 wait 
 echo
 echo "begin to make" 
-make 
+make --jobs="${N_JOBS}"
 wait
 echo
 echo "begin to make install" 

--- a/macros/load_env.sh
+++ b/macros/load_env.sh
@@ -5,10 +5,10 @@ echo "### Loading needed software versions ####################################"
 echo "#########################################################################"
 
 # Loading CMake version >= 3.8
-export PATH=/cvmfs/sft.cern.ch/lcg/releases/CMake/3.8.2-ece19/x86_64-slc6-gcc8-opt/bin:${PATH}
+export PATH=/cvmfs/sft.cern.ch/lcg/releases/CMake/3.8.2-ece19/x86_64-centos7-gcc8-opt/bin:${PATH}
 
 # Loading gcc8
-source /cvmfs/sft.cern.ch/lcg/contrib/gcc/8/x86_64-slc6-gcc8-opt/setup.sh
+source /cvmfs/sft.cern.ch/lcg/contrib/gcc/8/x86_64-centos7-gcc8-opt/setup.sh
 
 # Loading ROOT version >= 6.16
-source /afs/desy.de/project/ilcsoft/sw/x86_64_gcc82_sl6/root/6.18.04/bin/thisroot.sh
+source /afs/desy.de/project/ilcsoft/sw/x86_64_gcc82_centos7/root/6.18.04/bin/thisroot.sh

--- a/source/prew/include/Connect/LinkHelp.h
+++ b/source/prew/include/Connect/LinkHelp.h
@@ -1,6 +1,7 @@
 #ifndef LIB_LINKHELP_H
 #define LIB_LINKHELP_H 1
 
+#include <Data/PolLink.h>
 #include <Fit/FitPar.h>
 
 #include <functional>
@@ -15,8 +16,8 @@ namespace LinkHelp {
   **/
   
   std::function<double()> get_polfactor_lambda(
-    const std::string                         & chirality, 
-    const std::pair<std::string, std::string> & pol_pair, 
+    const std::string   & chirality, 
+    const Data::PolLink & pol_link, 
     Fit::ParVec *pars
   );
   

--- a/source/prew/include/CppUtils/Rnd.h
+++ b/source/prew/include/CppUtils/Rnd.h
@@ -1,0 +1,23 @@
+#ifndef LIB_RND_H
+#define LIB_RND_H 1
+
+#include <random>
+
+namespace PREW { 
+namespace CppUtils {
+  
+namespace Rnd {
+  /** Namespace for random number generation / fluctuation.
+  **/
+  
+  // Global random number generator to avoid duplication of random numbers
+  static std::random_device rnd_device;
+  static std::mt19937 rnd_gen(rnd_device());
+  
+  int poisson_fluctuate(double mean);
+}
+  
+}
+}
+
+#endif

--- a/source/prew/include/Data/PolLink.h
+++ b/source/prew/include/Data/PolLink.h
@@ -1,21 +1,45 @@
 #ifndef LIB_POLLINK_H
 #define LIB_POLLINK_H 1
 
-#include <CppUtils/Map.h>
+#include <string>
+#include <vector>
 
 namespace PREW {
 namespace Data {
 
-  struct PolLink {
-    /** Class that stores which polarisation configuration couples which 
-        individual beam polarisations together.
+  class PolLink {
+    /** Class that stores information about how to couple beam polarisations
+        for a given polarisation configuration at a given energy.
     **/
     
-    int m_energy {}; // This depends on the energy!
+    int m_energy {}; // Depends on the energy
+    std::string m_pol_config {}; // Name of polarisation configuration
     
-    // Map from polarisation setup to individual beam polarisation names
-    // => Rule: First electron polarisation, second positron polarisation
-    CppUtils::Map::StrToStrPairMap m_config_pol_links {};
+    // Name of single beam polarisation variables
+    std::string m_eM_pol {}; 
+    std::string m_eP_pol {};  
+    
+    // Signs of sign beam polarisation variables ("+" or "-")
+    std::string m_eM_sgn {};
+    std::string m_eP_sgn {};
+    
+    public:
+      // Constructors
+      PolLink() = default;
+      PolLink(
+        int energy, 
+        std::string pol_config, 
+        std::string eM_pol,     std::string eP_pol, 
+        std::string eM_sgn="+", std::string eP_sgn="+"
+      );
+      
+      int get_energy() const;
+      std::string get_pol_config() const;
+      std::string get_eM_pol() const;
+      std::string get_eP_pol() const;
+      
+      double get_eM_sgn_factor() const;
+      double get_eP_sgn_factor() const;
   };
 
   using PolLinkVec = std::vector<PolLink>;

--- a/source/prew/include/Fit/FitBin.h
+++ b/source/prew/include/Fit/FitBin.h
@@ -26,6 +26,8 @@ namespace Fit {
         std::function<double()> prd_fct=NULL
       );
       
+      void set_val_mst(double val_mst);
+      void set_val_unc(double val_unc);
       void set_prd_fct(std::function<double()> prd_fct); // Set prediction fct.
       
       double get_val_mst() const; // Get measured value

--- a/source/prew/include/Fit/FitPar.h
+++ b/source/prew/include/Fit/FitPar.h
@@ -21,6 +21,10 @@ namespace Fit {
     
     bool m_is_fixed {};
     
+    bool m_is_limited {false};
+    double m_upper_lim {};
+    double m_lower_lim {};
+    
     bool m_is_constraint {false};
     ParConstrGauss m_constrgauss {};
     
@@ -39,6 +43,11 @@ namespace Fit {
       double get_val_ini() const;   // Get initial value
       double get_unc_ini() const;   // Get initial value
       bool is_fixed() const;   // Get info if parameter is fixed
+      
+      void set_limits(double lower_lim, double upper_lim);
+      bool is_limited() const;
+      double get_lower_lim() const;
+      double get_upper_lim() const;
       
       void set_constrgauss(ParConstrGauss constrgauss);
       double calc_constr_chisq() const; // Chi-squared produced by constraint

--- a/source/prew/include/Fit/FitPar.h
+++ b/source/prew/include/Fit/FitPar.h
@@ -19,6 +19,8 @@ namespace Fit {
     double m_val_ini {}; // Initial value
     double m_unc_ini {}; // Initial guess of uncertainty -> Needed for Minuit
     
+    bool m_is_fixed {};
+    
     bool m_is_constraint {false};
     ParConstrGauss m_constrgauss {};
     
@@ -26,14 +28,23 @@ namespace Fit {
       double m_val_mod {}; // Modified value => Publicly accessible
       
       // Constructors
-      FitPar(std::string name, double val_ini, double unc_ini);
+      FitPar(
+        std::string name,
+        double val_ini,
+        double unc_ini,
+        bool is_fixed=false
+      );
       
       std::string get_name() const; // Get name
       double get_val_ini() const;   // Get initial value
       double get_unc_ini() const;   // Get initial value
+      bool is_fixed() const;   // Get info if parameter is fixed
       
       void set_constrgauss(ParConstrGauss constrgauss);
       double calc_constr_chisq() const; // Chi-squared produced by constraint
+      
+      void fix();     // fix the parameter
+      void release(); // release the parameter
       
       void reset(); // Reset to inital value
       

--- a/source/prew/include/Fit/FitResult.h
+++ b/source/prew/include/Fit/FitResult.h
@@ -20,6 +20,7 @@ namespace Fit {
     int m_cov_status {};
     
     bool operator==(const FitResult& result) const;
+    bool operator!=(const FitResult& result) const;
   };
   
 }

--- a/source/prew/include/Fit/FitResult.h
+++ b/source/prew/include/Fit/FitResult.h
@@ -25,4 +25,10 @@ namespace Fit {
 }
 }
 
+// Define operator for FitResult class
+template<typename OStream>
+OStream& operator<<(OStream& os, const PREW::Fit::FitResult& fr);
+
+#include <Fit/FitResult.tpp>
+
 #endif 

--- a/source/prew/include/Fit/FitResult.tpp
+++ b/source/prew/include/Fit/FitResult.tpp
@@ -1,0 +1,73 @@
+#ifndef LIB_FITRESULT_TPP
+#define LIB_FITRESULT_TPP 1
+
+#include <Fit/FitResult.h>
+
+#include "spdlog/fmt/ostr.h" // To allow output with spdlog
+
+//------------------------------------------------------------------------------
+
+template<typename OStream>
+OStream& operator<<(OStream& os, const PREW::Fit::FitResult& fr) {
+  /** Define what happens if a stream operator is called on the FitResult class.
+      (e.g. like `std::cout << fit_result;`)
+  **/
+  std::string output {};
+  output.append("Parameters:\n");
+  for (size_t par=0;par<fr.m_par_names.size();par++) {
+    output.append(
+      "p"  + std::to_string(par) 
+      + " : " + fr.m_par_names.at(par)
+      + " = " + std::to_string(fr.m_pars_fin.at(par)) 
+      + " +- " + std::to_string(fr.m_uncs_fin.at(par))
+      + "\n"
+    ) ;  
+  }
+  output.append("\n");
+  output.append("Covariance matrix:\n");
+  if (fr.m_cov_matrix.size() != 0) {
+    output.append("      ");
+    for (size_t par=0;par<fr.m_cov_matrix[0].size();par++) {
+      output.append("p" + std::to_string(par) + "    ");
+    }
+    output.append("\n");
+  }
+  for (size_t par1=0;par1<fr.m_cov_matrix.size();par1++) {
+    output.append("p" + std::to_string(par1) + "    ");
+    for (size_t par2=0;par2<fr.m_cov_matrix[par1].size();par2++) {
+      output.append(std::to_string(fr.m_cov_matrix[par1][par2]) + "  ");
+    }
+    output.append("\n");
+  }
+  output.append("\n");
+  output.append("Correlation matrix:\n");
+  if (fr.m_cor_matrix.size() != 0) {
+    output.append("      ");
+    for (size_t par=0;par<fr.m_cor_matrix[0].size();par++) {
+      output.append("p" + std::to_string(par) + "    ");
+    }
+    output.append("\n");
+  }
+  for (size_t par1=0;par1<fr.m_cor_matrix.size();par1++) {
+    output.append("p" + std::to_string(par1) + "    ");
+    for (size_t par2=0;par2<fr.m_cor_matrix[par1].size();par2++) {
+      output.append(std::to_string(fr.m_cor_matrix[par1][par2]) + "  ");
+    }
+    output.append("\n");
+  }
+  output.append("\n");
+
+  output.append("Fit quality measures:\n");
+  output.append("Chi^2 = " + std::to_string(fr.m_chisq_fin) + "\n");
+  output.append("EDM   = " + std::to_string(fr.m_edm_fin) + "\n");
+  output.append("Cov. matrix status : " + std::to_string(fr.m_cov_status));
+  
+  // Feed the output string into the given stream
+  os << output;
+  return os;
+}
+
+//------------------------------------------------------------------------------
+
+
+#endif 

--- a/source/prew/include/Fncts/FnctMap.h
+++ b/source/prew/include/Fncts/FnctMap.h
@@ -18,8 +18,12 @@ namespace Fncts {
   // This fixes the association of a funtion-ID string to an actual function.
   // All parameterisation functions must have their own unique ID!
   static const FnctMap prew_fnct_map = {
+    // Polynomials
+    {"Constant", Polynomial::constant_par},
     {"Quadratic1DPolynomial", Polynomial::quadratic_1D},
+    // Statisticals
     {"Gaussian1D", Statistic::gaussian_1D},
+    // Physis motivated
     {"PolarisationFactor", Physics::polarisation_factor}
   };
 

--- a/source/prew/include/Fncts/Polynomial.h
+++ b/source/prew/include/Fncts/Polynomial.h
@@ -14,6 +14,10 @@ namespace Polynomial {
                           const std::vector<double*>  &p);
   **/
   
+  double constant_par ( const std::vector<double>   &x,
+                        const std::vector<double>   &c,
+                        const std::vector<double*>  &p);
+                        
   double quadratic_1D ( const std::vector<double>   &x,
                         const std::vector<double>   &c,
                         const std::vector<double*>  &p);

--- a/source/prew/include/ToyMeas/Flct.h
+++ b/source/prew/include/ToyMeas/Flct.h
@@ -1,0 +1,21 @@
+#ifndef LIB_FLCT_H
+#define LIB_FLCT_H 1
+
+#include <CppUtils/Num.h>
+#include <CppUtils/Rnd.h>
+#include <Fit/FitBin.h>
+
+namespace PREW { 
+namespace ToyMeas {
+  
+namespace Flct {
+  /** Namespace for functions to fluctuate bins and distributions.
+  **/
+  
+  void poisson_fluctuate(Fit::FitBin &bin);
+}
+  
+}
+}
+
+#endif

--- a/source/prew/include/ToyMeas/ToyGenerator.h
+++ b/source/prew/include/ToyMeas/ToyGenerator.h
@@ -44,6 +44,7 @@ namespace ToyMeas {
       );
       
       Data::DiffDistrVec get_expected_distrs ( int energy ) const;
+      Data::DiffDistrVec get_fluctuated_distrs ( int energy ) const;
   };
 }
 }

--- a/source/prew/src/Connect/DataConnector.cpp
+++ b/source/prew/src/Connect/DataConnector.cpp
@@ -180,7 +180,10 @@ void DataConnector::fill_bins(
 
   // Set the prediction of each distribution
   for ( size_t bin=0; bin<bin_centers.size(); bin++ ) {
+    spdlog::debug("Binding functions for bin {}.", bin);
+    
     // -------------------- Get chiral signal prediction -----------------------
+    spdlog::debug("Getting chiral signal predictions.");
     double sigma_sig_LR = pred_LR.m_sig_distr[bin];
     double sigma_sig_RL = pred_RL.m_sig_distr[bin];
     double sigma_sig_LL = pred_LL.m_sig_distr[bin];
@@ -202,6 +205,7 @@ void DataConnector::fill_bins(
     // -------------------------------------------------------------------------
 
     // -------------------- Get chiral background prediction -------------------
+    spdlog::debug("Getting chiral background predictions.");
     double sigma_bkg_LR = pred_LR.m_bkg_distr[bin];
     double sigma_bkg_RL = pred_RL.m_bkg_distr[bin];
     double sigma_bkg_LL = pred_LL.m_bkg_distr[bin];
@@ -223,6 +227,7 @@ void DataConnector::fill_bins(
     // -------------------------------------------------------------------------
 
     // -------------------- Get polarised signal prediction --------------------
+    spdlog::debug("Getting polarised signal predictions.");
     auto alphas_sig_pol = linker_sig_pol.get_all_bonded_fncts_at_bin(bin, pars);
 
     // No longer sigma because includes lumi => #Events
@@ -243,6 +248,7 @@ void DataConnector::fill_bins(
     // -------------------------------------------------------------------------
 
     // -------------------- Get polarised background prediction ----------------
+    spdlog::debug("Getting polarised background predictions.");
     auto alphas_bkg_pol = linker_bkg_pol.get_all_bonded_fncts_at_bin(bin, pars);
 
     // No longer sigma because includes lumi => #Events
@@ -263,6 +269,7 @@ void DataConnector::fill_bins(
     // -------------------------------------------------------------------------
 
     // -------------------- Get total polarised prediction ---------------------
+    spdlog::debug("Getting total polarised predictions.");
     std::function<double()> pred_pol  =
       [pred_sig_pol,pred_bkg_pol]() { return pred_sig_pol() + pred_bkg_pol(); };
     // -------------------------------------------------------------------------

--- a/source/prew/src/Connect/DataConnector.cpp
+++ b/source/prew/src/Connect/DataConnector.cpp
@@ -94,13 +94,12 @@ void DataConnector::fill_bins(
   CppUtils::Vec::Matrix2D<double> bin_centers = diff_distr.m_bin_centers;
   
   // Find polarisation link for this energy
-  auto energy_condition = 
-    [energy](const Data::PolLink& link) {return link.m_energy==energy;};
+  auto energy_pol_condition = 
+    [energy,pol_config](const Data::PolLink& link) {
+      return (link.get_energy()==energy) && (link.get_pol_config()==pol_config);
+    };
   Data::PolLink pol_link = 
-    CppUtils::Vec::element_by_condition( m_pol_links, energy_condition );
-
-  // Individual beam polarisations
-  auto pol_pair = pol_link.m_config_pol_links.at(pol_config);
+    CppUtils::Vec::element_by_condition(m_pol_links, energy_pol_condition);
 
   // Find corresponding predicted distributions, links and coefficients
   Data::PredDistrVec predictions  = 
@@ -169,13 +168,13 @@ void DataConnector::fill_bins(
 
   // --- Get polarisation factor alpha functions -------------------------------
   auto pol_factor_LR = 
-    LinkHelp::get_polfactor_lambda(GlobalVar::Chiral::eLpR, pol_pair, pars);
+    LinkHelp::get_polfactor_lambda(GlobalVar::Chiral::eLpR, pol_link, pars);
   auto pol_factor_RL = 
-    LinkHelp::get_polfactor_lambda(GlobalVar::Chiral::eRpL, pol_pair, pars);
+    LinkHelp::get_polfactor_lambda(GlobalVar::Chiral::eRpL, pol_link, pars);
   auto pol_factor_LL = 
-    LinkHelp::get_polfactor_lambda(GlobalVar::Chiral::eLpL, pol_pair, pars);
+    LinkHelp::get_polfactor_lambda(GlobalVar::Chiral::eLpL, pol_link, pars);
   auto pol_factor_RR = 
-    LinkHelp::get_polfactor_lambda(GlobalVar::Chiral::eRpR, pol_pair, pars);
+    LinkHelp::get_polfactor_lambda(GlobalVar::Chiral::eRpR, pol_link, pars);
   // ---------------------------------------------------------------------------
 
   // Set the prediction of each distribution

--- a/source/prew/src/CppUtils/Rnd.cpp
+++ b/source/prew/src/CppUtils/Rnd.cpp
@@ -1,0 +1,23 @@
+#include <CppUtils/Rnd.h>
+
+#include <stdexcept>
+
+namespace PREW {
+namespace CppUtils {
+  
+//------------------------------------------------------------------------------
+
+int Rnd::poisson_fluctuate(double mean) {
+  /** Produce a random number from poisson distribution with given mean.
+  **/
+  if ( mean<0 ) { 
+    throw std::invalid_argument("Poisson not defined for negativ mean!");
+  }
+  std::poisson_distribution<int> distribution(mean);
+  return distribution(Rnd::rnd_gen);
+}
+
+//------------------------------------------------------------------------------
+
+}
+}

--- a/source/prew/src/Data/PolLink.cpp
+++ b/source/prew/src/Data/PolLink.cpp
@@ -1,0 +1,61 @@
+#include <Data/PolLink.h>
+
+#include <stdexcept>
+#include <string>
+
+namespace PREW {
+namespace Data {
+
+//------------------------------------------------------------------------------
+// Constructors
+
+PolLink::PolLink(
+  int energy, 
+  std::string pol_config, 
+  std::string eM_pol, std::string eP_pol, 
+  std::string eM_sgn, std::string eP_sgn
+) : 
+  m_energy(energy),
+  m_pol_config(pol_config),
+  m_eM_pol(eM_pol),
+  m_eP_pol(eP_pol),
+  m_eM_sgn(eM_sgn),
+  m_eP_sgn(eP_sgn)
+{
+  /** Construtor checks polarisation signs are valid.
+      Sign can be:
+        "+" => Take polarisation variable as is
+        "-" => Take negative of polarisation variable
+  **/
+  if ( (m_eM_sgn != "+") && (m_eM_sgn != "-") ) {
+    throw std::invalid_argument("Invalid e- pol. sign for : " + m_eM_pol);
+  } 
+  if ( (m_eP_sgn != "+") && (m_eP_sgn != "-") ) {
+    throw std::invalid_argument("Invalid e+ pol. sign for : " + m_eP_pol);
+  } 
+}
+
+//------------------------------------------------------------------------------
+// Get functions
+
+int PolLink::get_energy() const { return m_energy; }
+std::string PolLink::get_pol_config() const { return m_pol_config; }
+std::string PolLink::get_eM_pol() const { return m_eM_pol; }
+std::string PolLink::get_eP_pol() const { return m_eP_pol; }
+
+double PolLink::get_eM_sgn_factor() const {
+  /** Get the factor (+1 or -1) associated with the e- polarisation sign.
+  **/
+  return (m_eM_sgn == "-") ? -1.0 : 1.0;
+}
+
+double PolLink::get_eP_sgn_factor() const {
+  /** Get the factor (+1 or -1) associated with the e+ polarisation sign.
+  **/
+  return (m_eP_sgn == "-") ? -1.0 : 1.0;
+}
+
+//------------------------------------------------------------------------------
+
+}
+}

--- a/source/prew/src/Fit/ChiSqMinimizer.cpp
+++ b/source/prew/src/Fit/ChiSqMinimizer.cpp
@@ -113,7 +113,6 @@ void ChiSqMinimizer::update_result() {
   
   if (m_result != FitResult()) {
     spdlog::debug("FitResult not empty, will be overwritten.");
-    m_result = {};
   }
   
   unsigned int n_pars = m_container->m_fit_pars.size();

--- a/source/prew/src/Fit/ChiSqMinimizer.cpp
+++ b/source/prew/src/Fit/ChiSqMinimizer.cpp
@@ -75,7 +75,13 @@ void ChiSqMinimizer::minimize() {
   for ( unsigned int i_par=0; i_par<n_pars; i_par++ ){
     FitPar par = m_container->m_fit_pars[i_par];
     m_minimizer->SetVariable( i_par, par.get_name(), par.m_val_mod, par.get_unc_ini() );
-    if (par.is_fixed()) { m_minimizer->FixVariable(i_par); }
+    // Check if parameter is fixed or limited
+    if (par.is_fixed()) {
+      m_minimizer->FixVariable(i_par); 
+    } else if (par.is_limited()) {
+      m_minimizer->SetVariableLimits( 
+        i_par, par.get_upper_lim(), par.get_lower_lim());
+    }
   }
   
   // -------------------------------------------------------------------------//

--- a/source/prew/src/Fit/FitBin.cpp
+++ b/source/prew/src/Fit/FitBin.cpp
@@ -12,6 +12,8 @@ FitBin::FitBin(double val_mst, double val_unc, std::function<double()> prd_fct) 
 //------------------------------------------------------------------------------
 // set functions
 
+void FitBin::set_val_mst(double val_mst) { m_val_mst = val_mst; }
+void FitBin::set_val_unc(double val_unc) { m_val_unc = val_unc; }
 void FitBin::set_prd_fct(std::function<double()> prd_fct) {m_prd_fct = prd_fct;}
 
 //------------------------------------------------------------------------------

--- a/source/prew/src/Fit/FitPar.cpp
+++ b/source/prew/src/Fit/FitPar.cpp
@@ -7,8 +7,15 @@ namespace Fit {
 // Constructors
 
 
-FitPar::FitPar(std::string name, double val_ini, double unc_ini) : 
-  m_name(name), m_val_ini(val_ini), m_unc_ini(unc_ini), m_val_mod(val_ini) {}
+FitPar::FitPar(
+  std::string name,
+  double val_ini,
+  double unc_ini,
+  bool is_fixed
+) : m_name(name), m_val_ini(val_ini), m_unc_ini(unc_ini), m_is_fixed(is_fixed) 
+{
+  m_val_mod = m_val_ini;
+}
 
 //------------------------------------------------------------------------------
 // get functions
@@ -16,6 +23,7 @@ FitPar::FitPar(std::string name, double val_ini, double unc_ini) :
 std::string FitPar::get_name() const { return m_name; }
 double FitPar::get_val_ini() const { return m_val_ini; }
 double FitPar::get_unc_ini() const { return m_unc_ini; }
+bool FitPar::is_fixed() const { return m_is_fixed; }
   
 //------------------------------------------------------------------------------
 // Constraints
@@ -37,6 +45,9 @@ double FitPar::calc_constr_chisq() const {
 
 //------------------------------------------------------------------------------
 // Modifying functions
+
+void FitPar::fix()     { m_is_fixed=true; }
+void FitPar::release() { m_is_fixed=false; }
 
 void FitPar::reset() { m_val_mod = m_val_ini; }
 

--- a/source/prew/src/Fit/FitPar.cpp
+++ b/source/prew/src/Fit/FitPar.cpp
@@ -24,6 +24,9 @@ std::string FitPar::get_name() const { return m_name; }
 double FitPar::get_val_ini() const { return m_val_ini; }
 double FitPar::get_unc_ini() const { return m_unc_ini; }
 bool FitPar::is_fixed() const { return m_is_fixed; }
+bool FitPar::is_limited() const { return m_is_limited; }
+double FitPar::get_lower_lim() const { return m_lower_lim; }
+double FitPar::get_upper_lim() const { return m_upper_lim; }
   
 //------------------------------------------------------------------------------
 // Constraints
@@ -45,6 +48,14 @@ double FitPar::calc_constr_chisq() const {
 
 //------------------------------------------------------------------------------
 // Modifying functions
+
+void FitPar::set_limits(double lower_lim, double upper_lim) {
+  /** Set upper and lower limit for allowed parameter space.
+  **/
+  m_is_limited = true;
+  m_lower_lim = lower_lim;
+  m_upper_lim = upper_lim;
+}
 
 void FitPar::fix()     { m_is_fixed=true; }
 void FitPar::release() { m_is_fixed=false; }

--- a/source/prew/src/Fit/FitResult.cpp
+++ b/source/prew/src/Fit/FitResult.cpp
@@ -5,7 +5,7 @@ namespace PREW {
 namespace Fit {
 
 //------------------------------------------------------------------------------
-// Constructors
+// Operators
 
 bool FitResult::operator==(const FitResult& result) const {
   bool are_equal = true &&
@@ -29,6 +29,10 @@ bool FitResult::operator==(const FitResult& result) const {
   }
   
   return are_equal;
+}
+
+bool FitResult::operator!=(const FitResult& result) const {
+  return ! (*this == result);
 }
 
 //------------------------------------------------------------------------------

--- a/source/prew/src/Fncts/Physics.cpp
+++ b/source/prew/src/Fncts/Physics.cpp
@@ -11,14 +11,19 @@ double Physics::polarisation_factor (
   const std::vector<double*> &p
 ) {
   /** Calculate polarisation factor for given chirality (handled by 
-      coeffficients) and polarisations (handled by parameters).
+      coeffficients) and polarisations (amplitude handled by parameters, 
+      sign handled by coefficients).
       Coefficients: c[0] - electron chirality (-1 = L , +1 = R)
                     c[1] - positron chirality (-1 = L , +1 = R)
-      Parameters: p[0] - electron beam polarisation
-                  p[1] - positron beam polarisation
+                    c[2] - electron beam polarisation sign
+                    c[3] - positron beam polarisation sign
+      Parameters: p[0] - electron beam polarisation amplitude
+                  p[1] - positron beam polarisation amplitude
   **/
   
-  return 0.25 * ( 1 + c[0] * (*(p[0])) ) * ( 1 + c[1] * (*(p[1])) );
+  return 0.25 * 
+        ( 1 + c[0] * c[2] * (*(p[0])) ) * 
+        ( 1 + c[1] * c[3] * (*(p[1])) );
 }
 
 }

--- a/source/prew/src/Fncts/Polynomial.cpp
+++ b/source/prew/src/Fncts/Polynomial.cpp
@@ -7,6 +7,20 @@ namespace Fncts {
 
 //------------------------------------------------------------------------------
 
+double Polynomial::constant_par ( 
+  const std::vector<double>   &/*x*/,
+  const std::vector<double>   &/*c*/,
+  const std::vector<double*>  &p
+) {
+  /** Simple constant dependence on first parameter p[0].
+      No bin centers or coefficients required.
+  **/
+  return (*(p[0]));
+}
+
+
+//------------------------------------------------------------------------------
+
 double Polynomial::quadratic_1D ( 
   const std::vector<double> &x,
   const std::vector<double> &/*c*/,
@@ -21,6 +35,8 @@ double Polynomial::quadratic_1D (
   
   return (*(p[0])) + (*(p[1])) * x[0] + (*(p[2])) * std::pow( x[0], 2);
 }
+
+//------------------------------------------------------------------------------
 
 }
 }

--- a/source/prew/src/Input/Reading.cpp
+++ b/source/prew/src/Input/Reading.cpp
@@ -133,6 +133,12 @@ void Reading::read_RK_file(
       }
     }
     
+    // RK style files don't contain background distributions => 0-entry vectors
+    pred_LL.m_bkg_distr = std::vector<double>(pred_LL.m_sig_distr.size());
+    pred_LR.m_bkg_distr = std::vector<double>(pred_LR.m_sig_distr.size());
+    pred_RL.m_bkg_distr = std::vector<double>(pred_RL.m_sig_distr.size());
+    pred_RR.m_bkg_distr = std::vector<double>(pred_RR.m_sig_distr.size());
+    
     // Saving distributions in given pointers
     pred_distrs->push_back(pred_LL);
     pred_distrs->push_back(pred_LR);

--- a/source/prew/src/ToyMeas/Flct.cpp
+++ b/source/prew/src/ToyMeas/Flct.cpp
@@ -1,0 +1,28 @@
+#include <CppUtils/Num.h>
+#include <CppUtils/Rnd.h>
+#include <Fit/FitBin.h>
+#include <ToyMeas/Flct.h>
+
+#include <cmath>
+
+namespace PREW {
+namespace ToyMeas {
+  
+//------------------------------------------------------------------------------
+
+void Flct::poisson_fluctuate(Fit::FitBin &bin) {
+  /** Poisson fluctuate the measured value in the bin and adjust the 
+      uncertainty.
+  **/
+  bin.set_val_mst( CppUtils::Rnd::poisson_fluctuate(bin.get_val_mst()) );
+  
+  // If content zero keep previous uncertainty, else poisson uncertainty
+  if ( ! CppUtils::Num::equal_to_eps(bin.get_val_mst(),0.0) ) { 
+    bin.set_val_unc( std::sqrt(bin.get_val_mst()) );
+  }
+}
+
+//------------------------------------------------------------------------------
+
+}
+}

--- a/source/prew/src/ToyMeas/ToyGenerator.cpp
+++ b/source/prew/src/ToyMeas/ToyGenerator.cpp
@@ -50,7 +50,6 @@ ToyGenerator::ToyGenerator(
     for (const auto& [pol_config, pol_pair]: pol_link.m_config_pol_links) {
       pol_configs_per_energies[energy].insert(pol_config);
     }
-    // TODO This as functionality of connector?????
   }
   
   // Check what was found
@@ -61,13 +60,16 @@ ToyGenerator::ToyGenerator(
       continue;
     }
     spdlog::debug(
-      "For E={} found {} distribution and {} pol. configurations.",
+      "For E={} found {} distributions and {} pol. configurations.",
+      energy,
       distr_per_energies.at(energy).size(), 
       pol_configs_per_energies.at(energy).size()
     );
   }
   
+
   // Loop over all distributions found at their respective energies
+  spdlog::debug("Start setting up basic toy distributions.");
   for (const int & energy: energies) {
     for (const auto & distr_name: distr_per_energies.at(energy)) {
       // Get distribution setup bin centers from first prediction
@@ -77,6 +79,10 @@ ToyGenerator::ToyGenerator(
         
       // Loop over all polarisations for the given energy
       for (const auto& pol_config: pol_configs_per_energies.at(energy)) {
+        spdlog::debug( 
+          "Setting up distribution for : {}, {}, {}.",
+          energy, distr_name, pol_config
+        );
         
         // Create a differential distribution for this polarisation config.
         // Fit bins empty for now, prediction to be set

--- a/source/prew/src/ToyMeas/ToyGenerator.cpp
+++ b/source/prew/src/ToyMeas/ToyGenerator.cpp
@@ -42,12 +42,15 @@ ToyGenerator::ToyGenerator(
     // Find polarisation link for this energy 
     // => which polarisations exist?
     auto energy_condition = 
-      [energy](const Data::PolLink& link) {return link.m_energy==energy;};
-    Data::PolLink pol_link = 
-      CppUtils::Vec::element_by_condition( m_connector.get_pol_links(), energy_condition );
+      [energy](const Data::PolLink& link) {return link.get_energy()==energy;};
+    Data::PolLinkVec pol_links = 
+      CppUtils::Vec::subvec_by_condition( 
+        m_connector.get_pol_links(), energy_condition 
+      );
       
     // Find all available polarisations at energy from polarisation link
-    for (const auto& [pol_config, pol_pair]: pol_link.m_config_pol_links) {
+    for (const auto& pol_link: pol_links) {
+      std::string pol_config = pol_link.get_pol_config();
       pol_configs_per_energies[energy].insert(pol_config);
     }
   }

--- a/source/prew/src/ToyMeas/ToyGenerator.cpp
+++ b/source/prew/src/ToyMeas/ToyGenerator.cpp
@@ -4,6 +4,7 @@
 #include <Data/DistrInfo.h>
 #include <Data/DistrUtils.h>
 #include <GlobalVar/Chiral.h>
+#include <ToyMeas/Flct.h>
 #include <ToyMeas/ToyGenerator.h>
 
 #include "spdlog/spdlog.h"
@@ -134,6 +135,21 @@ Data::DiffDistrVec ToyGenerator::get_expected_distrs ( int energy ) const {
   }
   
   return output_distrs;
+}
+
+Data::DiffDistrVec ToyGenerator::get_fluctuated_distrs ( int energy ) const {
+  /** Get poisson fluctuated versions of the expected distributions at the given
+      energy.
+  **/
+  Data::DiffDistrVec distrs = this->get_expected_distrs(energy);
+  
+  // Fluctuate each bin with a Poisson distribution on its value and adjust unc.
+  for (auto & distr: distrs) {
+    for (auto & bin: distr.m_distribution) {
+      Flct::poisson_fluctuate(bin);
+    }
+  }
+  return distrs;
 }
 
 //------------------------------------------------------------------------------

--- a/source/tests/Connect/test_DataConnector.cpp
+++ b/source/tests/Connect/test_DataConnector.cpp
@@ -42,7 +42,9 @@ TEST(TestDataConnector, ReadFunctions) {
   PredLinkVec  pred_links {
     { info_LR, { {"Gaussian1D", {"A_LR", "mu", "sigma"}} }, {} },
   };
-  PolLinkVec   pol_links { {500, { {"e-p+", {"ePol", "pPol"}} }} };
+  PolLinkVec pol_links { 
+    PolLink(500, "e-p+", "ePol", "pPol", "-", "+")
+   };
   
   DataConnector connector {pred_distrs,coef_distrs,pred_links,pol_links};
 
@@ -75,8 +77,8 @@ TEST(TestDataConnector, DistrFilling) {
     {"A_LR", 1, 0},
     {"mu", 0, 0},
     {"sigma", 0.5, 0},
-    {"ePol", -0.80, 0},
-    {"pPol", +0.30, 0}
+    {"ePol", 0.80, 0},
+    {"pPol", 0.30, 0}
   };
   CoefDistrVec coef_distrs {};
   PredLinkVec  pred_links {
@@ -87,7 +89,7 @@ TEST(TestDataConnector, DistrFilling) {
     { info_pol, { {"Gaussian1D", {"A_pol", "mu", "sigma"}} }, {} }
   };
   PolLinkVec   pol_links {
-    {500, { {"e-p+", {"ePol", "pPol"}} }}
+    PolLink(500, "e-p+", "ePol", "pPol", "-", "+")
   };
   
   // Connector has task to connect all of that

--- a/source/tests/Connect/test_LinkHelp.cpp
+++ b/source/tests/Connect/test_LinkHelp.cpp
@@ -1,5 +1,6 @@
 #include <Connect/LinkHelp.h>
 #include <CppUtils/Num.h>
+#include <Data/PolLink.h>
 #include <Fit/FitPar.h>
 #include <GlobalVar/Chiral.h>
 
@@ -10,6 +11,7 @@
 
 using namespace PREW::Connect;
 using namespace PREW::CppUtils;
+using namespace PREW::Data;
 using namespace PREW::Fit;
 using namespace PREW::GlobalVar;
 
@@ -19,15 +21,15 @@ using namespace PREW::GlobalVar;
 TEST(TestLinkHelp, PolFactorLambdas) {
   // Test function that returns lambda for polarisation factor
   ParVec pars {
-    {"ePol", -1.0, 0.0}, // e- Pol.: -100%
-    {"pPol", +1.0, 0.0}, // e+ Pol.: +100%
+    {"ePol", 1.0, 0.0}, // e- Pol.: 100% -> Sign in PolLink (-)
+    {"pPol", 1.0, 0.0}, // e+ Pol.: 100% -> Sign in PolLink (+)
   };
-  std::pair<std::string,std::string> pol_pair {"ePol","pPol"};
+  PolLink pol_link {500, "test", "ePol", "pPol", "-", "+"};
   
-  auto factor_LR = LinkHelp::get_polfactor_lambda(Chiral::eLpR,pol_pair,&pars);
-  auto factor_RL = LinkHelp::get_polfactor_lambda(Chiral::eRpL,pol_pair,&pars);
-  auto factor_LL = LinkHelp::get_polfactor_lambda(Chiral::eLpL,pol_pair,&pars);
-  auto factor_RR = LinkHelp::get_polfactor_lambda(Chiral::eRpR,pol_pair,&pars);
+  auto factor_LR = LinkHelp::get_polfactor_lambda(Chiral::eLpR,pol_link,&pars);
+  auto factor_RL = LinkHelp::get_polfactor_lambda(Chiral::eRpL,pol_link,&pars);
+  auto factor_LL = LinkHelp::get_polfactor_lambda(Chiral::eLpL,pol_link,&pars);
+  auto factor_RR = LinkHelp::get_polfactor_lambda(Chiral::eRpR,pol_link,&pars);
   
   ASSERT_EQ(factor_LR(),1);
   ASSERT_EQ(factor_RL(),0);
@@ -35,8 +37,8 @@ TEST(TestLinkHelp, PolFactorLambdas) {
   ASSERT_EQ(factor_RR(),0);
   
   // Change polarisations and check that factors changed
-  pars[0].m_val_mod = -0.8; // e- Pol.: -80%
-  pars[1].m_val_mod = +0.3; // e+ Pol.: +30%
+  pars[0].m_val_mod = 0.8; // e- Pol.: -80%
+  pars[1].m_val_mod = 0.3; // e+ Pol.: +30%
   
   ASSERT_EQ(Num::equal_to_eps(factor_LR(), 0.585, 1e-9), true)
     << "Got " << factor_LR() << " expected " << 0.585;

--- a/source/tests/CppUtils/test_Rnd.cpp
+++ b/source/tests/CppUtils/test_Rnd.cpp
@@ -1,0 +1,26 @@
+#include <gtest/gtest.h>
+#include <CppUtils/Num.h>
+#include <CppUtils/Rnd.h>
+
+using namespace PREW::CppUtils;
+
+//------------------------------------------------------------------------------
+// Tests for random number generation
+
+TEST(TestRnd, PoissonRange) {
+  ASSERT_THROW(Rnd::poisson_fluctuate(-1.0), std::invalid_argument);
+}
+
+TEST(TestRnd, PoissonMeanTests) {
+  std::vector<double> means {0.5, 2.5, 15.0};
+  int n_vals = 10000;
+  for (const auto & mean: means){
+    double sum = 0;
+    for (int i=0; i<n_vals; i++) { sum += Rnd::poisson_fluctuate(mean); }
+    double result_mean = sum / double(n_vals);
+    ASSERT_EQ(Num::equal_to_eps(result_mean, mean, 5e-2*mean), true)
+      << "Expected mean: " << mean << " , got: " << result_mean;
+  }
+}
+
+//------------------------------------------------------------------------------

--- a/source/tests/Data/test_PolLink.cpp
+++ b/source/tests/Data/test_PolLink.cpp
@@ -1,0 +1,34 @@
+#include <Data/PolLink.h>
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+using namespace PREW::Data;
+
+//------------------------------------------------------------------------------
+// Tests for polarisation instruction class
+
+TEST(TestPolLink, DefaultConstructor) {
+  PolLink pol_link {};
+  
+  ASSERT_EQ(pol_link.get_energy(),0);
+  ASSERT_STREQ(pol_link.get_pol_config().c_str(),"");
+  ASSERT_STREQ(pol_link.get_eM_pol().c_str(),"");
+  ASSERT_STREQ(pol_link.get_eP_pol().c_str(),"");
+  ASSERT_EQ(pol_link.get_eM_sgn_factor(),+1.0);
+  ASSERT_EQ(pol_link.get_eP_sgn_factor(),+1.0);
+}
+
+TEST(TestPolLink, SimpleConstructor) {
+  PolLink pol_link {500,"e-p-","ePol","pPol","-","-"};
+  
+  ASSERT_EQ(pol_link.get_energy(),500);
+  ASSERT_STREQ(pol_link.get_pol_config().c_str(),"e-p-");
+  ASSERT_STREQ(pol_link.get_eM_pol().c_str(),"ePol");
+  ASSERT_STREQ(pol_link.get_eP_pol().c_str(),"pPol");
+  ASSERT_EQ(pol_link.get_eM_sgn_factor(),-1.0);
+  ASSERT_EQ(pol_link.get_eP_sgn_factor(),-1.0);
+}
+
+//------------------------------------------------------------------------------

--- a/source/tests/Fit/test_ChiSqMinimizer.cpp
+++ b/source/tests/Fit/test_ChiSqMinimizer.cpp
@@ -152,4 +152,19 @@ TEST(TestChiSqMinimizer, SecondOrderPolynomialFit) {
   double result_chisq = result.m_chisq_fin;
   int n_dof = n_bins - 3; // 3->#parameters
   EXPECT_EQ( fabs(result_chisq/double(n_bins)-1.0)<0.2, true) << "Result chi^2/n_dof: " << result_chisq/double(n_bins);
+  
+  // Fix parameter "a" to true value and test if all works well 
+  // and that "a" does not change
+  container.m_fit_pars[0].m_val_mod = true_a;
+  container.m_fit_pars[0].fix();
+  
+  // Here we go again...
+  chi_sq_minimizer.minimize();
+  auto const new_result = chi_sq_minimizer.get_result();
+  double new_result_a = new_result.m_pars_fin[0];
+  double new_result_b = new_result.m_pars_fin[1];
+  double new_result_c = new_result.m_pars_fin[2];
+  EXPECT_EQ( fabs(new_result_a-true_a)<1e-9, true) << "True a: " << true_a << " , Result a: " << new_result_a;
+  EXPECT_EQ( fabs(new_result_b-true_b)<0.03, true) << "True b: " << true_b << " , Result b: " << new_result_b;
+  EXPECT_EQ( fabs(new_result_c-true_c)<0.03, true) << "True c: " << true_c << " , Result c: " << new_result_c;
 }

--- a/source/tests/Fit/test_FitBin.cpp
+++ b/source/tests/Fit/test_FitBin.cpp
@@ -18,6 +18,18 @@ TEST(TestFitbin, ReturnsCorrectVals) {
   ASSERT_EQ(fb2.get_val_unc(), 0.0);
 }
 
+TEST(TestFitbin, ValSetting) {
+  FitBin fb {};
+  fb.set_val_mst(2.4);
+  fb.set_val_unc(0.3);
+  ASSERT_EQ(fb.get_val_mst(), 2.4);
+  ASSERT_EQ(fb.get_val_unc(), 0.3);
+  fb.set_val_mst(-7.0);
+  fb.set_val_unc(10.5);
+  ASSERT_EQ(fb.get_val_mst(), -7.0);
+  ASSERT_EQ(fb.get_val_unc(), 10.5);
+}
+
 TEST(TestFitbin, CorrectTrivialPrediction) {
   std::function<double()> trivial_prd = []() { return 2.1; };
   FitBin fb (0, 0, trivial_prd);

--- a/source/tests/Fit/test_FitPar.cpp
+++ b/source/tests/Fit/test_FitPar.cpp
@@ -11,17 +11,19 @@ using namespace PREW::CppUtils;
 
 TEST(TestFitPar, ReturnsCorrectIni) {
   FitPar fp1 ("fp1", 0.00055, 0.01);
-  FitPar fp2 ("fp2", -200.5, 0.01);
+  FitPar fp2 ("fp2", -200.5, 0.01, true);
   
   ASSERT_EQ(fp1.get_val_ini(), 0.00055);
   ASSERT_EQ(fp1.get_unc_ini(), 0.01);
   ASSERT_EQ(fp1.m_val_mod, 0.00055);
   ASSERT_STREQ(fp1.get_name().c_str(), "fp1");
+  ASSERT_EQ(fp1.is_fixed(), false);
   
   ASSERT_EQ(fp2.get_val_ini(), -200.5);
   ASSERT_EQ(fp2.get_unc_ini(), 0.01);
   ASSERT_EQ(fp2.m_val_mod, -200.5);
   ASSERT_STREQ(fp2.get_name().c_str(), "fp2");
+  ASSERT_EQ(fp2.is_fixed(), true);
 }
 
 TEST(TestFitPar, ProperReset) {
@@ -53,18 +55,20 @@ TEST(TestFitPar, EqualOperator) {
 
 TEST(TestFitPar, CopyAssignmentOperator) {
   FitPar fp1 ("fp1", 0, 0.01);
-  FitPar fp2 ("fp2", 1, 0.05);
+  FitPar fp2 ("fp2", 1, 0.05, true);
   FitPar fp2_copy = fp2;
   ASSERT_EQ(fp1 == fp2, false); // Compares only name string
   ASSERT_EQ(fp2 == fp2_copy, true);
   ASSERT_EQ(Num::equal_to_eps(fp2.get_val_ini(), fp2_copy.get_val_ini()), true);
   ASSERT_EQ(Num::equal_to_eps(fp2.get_unc_ini(), fp2_copy.get_unc_ini()), true);
+  ASSERT_EQ(fp2.is_fixed(), fp2_copy.is_fixed());
   
   fp2 = fp1; // Overwrite fp1
   ASSERT_EQ(fp1 == fp2, true);
   ASSERT_EQ(fp2 == fp2_copy, false);
   ASSERT_EQ(Num::equal_to_eps(fp2.get_val_ini(), fp2_copy.get_val_ini()), false);
   ASSERT_EQ(Num::equal_to_eps(fp2.get_unc_ini(), fp2_copy.get_unc_ini()), false);
+  ASSERT_EQ(fp2.is_fixed() == fp2_copy.is_fixed(), false);
 }
 
 TEST(TestFitPar, ConstrCalcWithoutConstr) {
@@ -88,4 +92,14 @@ TEST(TestFitPar, GaussConstrModifiedValue) {
   fp.m_val_mod = 5;
   // constr: ( (5-1)/2 )^2 = 4
   ASSERT_EQ(fp.calc_constr_chisq(), 4);
+}
+
+TEST(TestFitPar, ParFixing) {
+  FitPar fp ("fp", 0, 0, false); // Not fixed
+  ASSERT_EQ(fp.is_fixed(), false);
+  
+  fp.fix(); 
+  ASSERT_EQ(fp.is_fixed(), true);
+  fp.release(); 
+  ASSERT_EQ(fp.is_fixed(), false);
 }

--- a/source/tests/Fit/test_FitPar.cpp
+++ b/source/tests/Fit/test_FitPar.cpp
@@ -103,3 +103,14 @@ TEST(TestFitPar, ParFixing) {
   fp.release(); 
   ASSERT_EQ(fp.is_fixed(), false);
 }
+
+TEST(TestFitPar, LimitSetting) {
+  FitPar fp ("fp", 0, 0); // Parameter without limits
+  ASSERT_EQ(fp.is_limited(), false);
+  ASSERT_EQ(fp.get_upper_lim(), 0);
+  ASSERT_EQ(fp.get_lower_lim(), 0);
+  
+  fp.set_limits(-1.5, 1000);
+  ASSERT_EQ(fp.get_lower_lim(), -1.5);
+  ASSERT_EQ(fp.get_upper_lim(), 1000);
+}

--- a/source/tests/Fit/test_FitResult.cpp
+++ b/source/tests/Fit/test_FitResult.cpp
@@ -3,13 +3,15 @@
 
 using namespace PREW::Fit;
 
-TEST(TestFitResult, EqualOperatorTest) {
+TEST(TestFitResult, EqualityOperators) {
   FitResult r1 {};
   ASSERT_EQ(r1 == r1, true);
+  ASSERT_EQ(r1 != r1, false);
   
   FitResult r2 {};
   r2.m_chisq_fin = 1.0;
   ASSERT_EQ(r1 == r2, false);
+  ASSERT_EQ(r1 != r2, true);
   
   FitResult r3 {};
   FitResult r4 {};
@@ -17,6 +19,8 @@ TEST(TestFitResult, EqualOperatorTest) {
   r4.m_par_names = std::vector<std::string> {"a"};
   ASSERT_EQ(r1 == r3, false);
   ASSERT_EQ(r3 == r4, false);
+  ASSERT_EQ(r1 != r3, true);
+  ASSERT_EQ(r3 != r4, true);
   
   FitResult r5 {};
   FitResult r6 {};
@@ -24,6 +28,8 @@ TEST(TestFitResult, EqualOperatorTest) {
   r6.m_cov_matrix = std::vector<std::vector<double>> ( 4, std::vector<double>(4, 2.0) );
   ASSERT_EQ(r1 == r5, false);
   ASSERT_EQ(r5 == r6, false);
+  ASSERT_EQ(r1 != r5, true);
+  ASSERT_EQ(r5 != r6, true);
 }
 
 TEST(TestFitResult, StreamOperatorEmptyResult) {

--- a/source/tests/Fit/test_FitResult.cpp
+++ b/source/tests/Fit/test_FitResult.cpp
@@ -25,3 +25,12 @@ TEST(TestFitResult, EqualOperatorTest) {
   ASSERT_EQ(r1 == r5, false);
   ASSERT_EQ(r5 == r6, false);
 }
+
+TEST(TestFitResult, StreamOperatorEmptyResult) {
+  FitResult r {};
+  std::stringstream buffer;
+  buffer << r;
+  std::string output = buffer.str();
+  std::string expected = "Parameters:\n\nCovariance matrix:\n\nCorrelation matrix:\n\nFit quality measures:\nChi^2 = 0.000000\nEDM   = 0.000000\nCov. matrix status : 0";
+  ASSERT_STREQ(output.c_str(),expected.c_str());
+}

--- a/source/tests/Fncts/test_Physics.cpp
+++ b/source/tests/Fncts/test_Physics.cpp
@@ -15,11 +15,13 @@ TEST(TestPhysics, PolarisationFactor) {
   // Test the polarisation factor function.
   std::vector<double> c {
     +1, // e- chirality = R
-    -1  // e+ chirality = L
+    -1, // e+ chirality = L
+    -1, // e- beam polarisation sign
+    +1  // e- beam polarisation sign
   };
   std::vector<double> p_vals {  
-    -0.2, // e- beam polarisation
-    0.6   // e+ beam polarisation
+    0.2, // e- beam polarisation amplitude
+    0.6  // e+ beam polarisation amplitude
   };
   std::vector<double*> p_ptrs {};
   for (double & p: p_vals) { p_ptrs.push_back(&p); }

--- a/source/tests/Fncts/test_Polynomial.cpp
+++ b/source/tests/Fncts/test_Polynomial.cpp
@@ -11,6 +11,27 @@ using namespace PREW::Fncts;
 //------------------------------------------------------------------------------
 // Check that polynomial functions are correctly implemented
 
+TEST(TestPolynomial, ConstantPar) {
+  // Test function that simply mirrors the parameter
+  std::vector<double> c {};
+  std::vector<double> p_vals {1.0};
+  std::vector<double*> p_ptrs {&(p_vals[0])};
+
+  ASSERT_EQ( 
+    Num::equal_to_eps( Polynomial::constant_par({},c,p_ptrs), 1.0, 1e-9), true 
+  ) << "Expected " << 1.0 << " got " << Polynomial::constant_par({},c,p_ptrs);
+  
+  p_vals[0] = -0.5;
+  ASSERT_EQ( 
+    Num::equal_to_eps( Polynomial::constant_par({},c,p_ptrs), -0.5, 1e-9), true 
+  ) << "Expected " << -0.5 << " got " << Polynomial::constant_par({},c,p_ptrs);
+  
+  p_vals[0] = 2000.;
+  ASSERT_EQ( 
+    Num::equal_to_eps( Polynomial::constant_par({},c,p_ptrs), 2000., 1e-9), true 
+  ) << "Expected " << 2000. << " got " << Polynomial::constant_par({},c,p_ptrs);
+}
+
 TEST(TestPolynomial, Gaussian1D) {
   std::vector<double> c {};
   std::vector<double> p_vals {  1.0, // Offset

--- a/source/tests/Input/test_DataReader.cpp
+++ b/source/tests/Input/test_DataReader.cpp
@@ -40,6 +40,13 @@ TEST(TestDataReader, TestRKFileReading) {
   ASSERT_EQ(predicted_distributions.size(), 6*4);
   // Contains for 3 processes (*4) each 9 coefficients 
   ASSERT_EQ(prediction_coefficients.size(), 3*4*9);
+  
+  // There should be no background predictions
+  for (const auto & pred: predicted_distributions) {
+    double sum_bkg = 0;
+    for (const auto & bin: pred.m_bkg_distr) { sum_bkg += bin; }
+    ASSERT_EQ(sum_bkg, 0.0) << "RK style file should not contain bkg.";
+  }
 }
 
 //------------------------------------------------------------------------------

--- a/source/tests/ToyMeas/test_Flct.cpp
+++ b/source/tests/ToyMeas/test_Flct.cpp
@@ -1,0 +1,25 @@
+#include <CppUtils/Num.h>
+#include <Fit/FitBin.h>
+#include <ToyMeas/Flct.h>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+using namespace PREW::CppUtils;
+using namespace PREW::Fit;
+using namespace PREW::ToyMeas;
+
+//------------------------------------------------------------------------------
+// Test random fluctuation of FitBin values
+
+TEST(TestFlct, BinGetsFluctuated) {
+  FitBin bin(20.5,0.5);
+  Flct::poisson_fluctuate(bin);
+  
+  ASSERT_EQ( Num::equal_to_eps(fmod(bin.get_val_mst(), 1.0), 0.0), true )
+    << "Poisson fluctuation gave non-integer: " << bin.get_val_mst();
+  ASSERT_EQ( (bin.get_val_unc() != 0.5), true );
+}
+
+//------------------------------------------------------------------------------

--- a/source/tests/ToyMeas/test_ToyGenerator.cpp
+++ b/source/tests/ToyMeas/test_ToyGenerator.cpp
@@ -44,8 +44,8 @@ TEST(TestToyGenerator, SimpleConstructor) {
     {"A_LR", 1, 0},
     {"mu", 0, 0},
     {"sigma", 0.5, 0},
-    {"ePol", -0.60, 0},
-    {"pPol", +0.20, 0}
+    {"ePol", 0.60, 0},
+    {"pPol", 0.20, 0}
   };
   CoefDistrVec coef_distrs {};
   PredLinkVec  pred_links {
@@ -56,7 +56,7 @@ TEST(TestToyGenerator, SimpleConstructor) {
     { info_pol, { {"Gaussian1D", {"A_pol", "mu", "sigma"}} }, {} }
   };
   PolLinkVec   pol_links {
-    {500, { {"e-p+", {"ePol", "pPol"}} }}
+    PolLink(500, "e-p+", "ePol", "pPol", "-", "+")
   };
   
   DataConnector connector {pred_distrs,coef_distrs,pred_links,pol_links};

--- a/source/tests/ToyMeas/test_ToyGenerator.cpp
+++ b/source/tests/ToyMeas/test_ToyGenerator.cpp
@@ -69,9 +69,17 @@ TEST(TestToyGenerator, SimpleConstructor) {
   ASSERT_EQ(expected_distrs[0].m_distribution.size(), 2);
   
   // Is the distribution content accurate?
+  double bin0_expected = 1.44095492471;
   double bin0_content = expected_distrs[0].m_distribution[0].get_val_mst();
-  ASSERT_EQ( Num::equal_to_eps(bin0_content, 1.44095492471, 1e-9), true )
-    << "Expected " << 1.44095492471 << " got " << bin0_content;
+  ASSERT_EQ( Num::equal_to_eps(bin0_content, bin0_expected, 1e-9), true )
+    << "Expected " << bin0_expected << " got " << bin0_content;
+    
+  // Do toy fluctuations work?
+  auto fluctuated_distrs = test_gen.get_fluctuated_distrs(500);
+  ASSERT_EQ(fluctuated_distrs.size(), 1);
+  ASSERT_EQ(fluctuated_distrs[0].m_distribution.size(), 2);
+  double bin0_fluctuated = fluctuated_distrs[0].m_distribution[0].get_val_mst();
+  ASSERT_EQ( Num::equal_to_eps(bin0_fluctuated, bin0_expected, 1e-9), false );
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
- Change compilation macro so that different input arguments can be supplied.
- Add multithreaded mode to compilation macro.
- Remark multithreaded compilation possibility in Readme.
- Change paths in load_env.sh script to CentOS7 installations.
- Add parametrisation function in Polynomial namespace that simply mirrors the parameter value.
- Add constant parameter function to function map.
- Add test for constant parameter function.
- Add debug statements to DataConnector.
- Add/fix debug statements in ToyGenerator.
- Add option to fix and release FitPar in its constructor and using separat functions.
- Add test for FitPar fixing.
- Apply parameter fixing in ChiSqMinimizer by fixing them in the minimization process and ignoring possible constraints on them.
- Initialize variables of minimizer using the modified instead of the initial value to allow changing of the starting value.
- Adjust ChiSqMinimizer test to also test fixing of parameters.
- Add filling of empty background bins to RK style file.
- Test that RK style file does not contain bkg.
- Add a stream operator for FitResult class.
- Add simple test for stream operator of FitResult task for empty class instance.
- Add not-equal operator to FitResult.
- Adjust test of FitResult to also test not-equal operator.
- Add option to set upper and lower limit to fit parameter.
- Add test for FitPar limit setting.
- Apply parameter limits in ChiSqMinimizer minimization.
- Test parameter limiting in ChiSqMinimizer fitting test.
- Modify PolLink so that it is class instead of struct and that it separates the polarisation amplitude (as parameter) and the polarisation sign (as constant).
- Add test for modified PolLink class.
- Adjust polarisation factor function and its test to new separation of polarisation amplitude and polarisation sign.
- Adjust LinkHelp function that gives polarisation factor lambda to use modified PolLink class with separated polarisation sign and amplitude.
- Adjust LinkHelp test to modified polarisation factor lambda function.
- Adjust DataConnector and its test to separation of polarisation amplitude and polarisation sign using PolLink class.
- Adjust ToyGenerator and its test to separation of polarisation amplitude and polarisation sign using PolLink class.
- PR #4 : Correct polarisation handling
- Add new namespace for random number generation including a global random number generator.
- Add function to get poisson fluctuated number.
- Add test for poisson fluctuation.
- Add functions to FitBin that allow setting of measurement value and uncertainty.
- Add test for FitBin value setting.
- Add namespace and function to fluctuate a FitBin.
- Add test for FitBin fluctuation.
- In ToyGenerator add function that returns fluctuation prediction as a toy measurement.
- Include testing of toy fluctuation in ToyGenerator test.
- PR #5 : Add toy fluctuations