### PR TITLE
Clean up

### DIFF
--- a/source/prew/include/Connect/Linker.h
+++ b/source/prew/include/Connect/Linker.h
@@ -3,9 +3,9 @@
 
 #include <CppUtils/Vec.h>
 #include <Data/CoefDistr.h>
-#include <Data/FnctLink.h>
+#include <Data/FctLink.h>
 #include <Fit/FitPar.h>
-#include <Fncts/FnctMap.h>
+#include <Fcts/FctMap.h>
 
 #include <functional>
 #include <string>
@@ -19,25 +19,25 @@ namespace Connect {
         each bin of the distribution.
     **/
     
-    Data::FnctLinkVec m_fncts_links {};
+    Data::FctLinkVec m_fcts_links {};
     CppUtils::Vec::Matrix2D<double> m_bin_centers {};
     Data::CoefDistrVec m_coefs {};
     
     public:
       // Constructors
-      Linker( Data::FnctLinkVec fncts_links,
+      Linker( Data::FctLinkVec fcts_links,
               CppUtils::Vec::Matrix2D<double> bin_centers,
               Data::CoefDistrVec coefs
              );
       
       // Core functionality
-      std::function<double()> get_bonded_fnct_at_bin(
-        const std::string &fnct_name,
+      std::function<double()> get_bonded_fct_at_bin(
+        const std::string &fct_name,
         size_t bin,
         Fit::ParVec *pars
       ) const;
       
-      std::vector<std::function<double()>> get_all_bonded_fncts_at_bin(
+      std::vector<std::function<double()>> get_all_bonded_fcts_at_bin(
         size_t bin,
         Fit::ParVec *pars
       ) const;

--- a/source/prew/include/CppUtils/Fct.h
+++ b/source/prew/include/CppUtils/Fct.h
@@ -7,13 +7,13 @@
 namespace PREW {
 namespace CppUtils {
 
-namespace Fnct {
+namespace Fct {
   /** Namespace for C++ helper functions and classes related to std::function.
   **/
   
   // Function which has three input parameter vectors,
   // In PrEW like: coordinates,parameters,coefficients
-  using ParametrisationFnct = std::function<double(const std::vector<double> &,
+  using ParametrisationFct = std::function<double(const std::vector<double> &,
                                                    const std::vector<double> &,
                                                    const std::vector<double*> &)
                                             >;

--- a/source/prew/include/Data/FctLink.h
+++ b/source/prew/include/Data/FctLink.h
@@ -7,17 +7,17 @@
 namespace PREW {
 namespace Data {
   
-  struct FnctLink {
+  struct FctLink {
     /** Class that stores the names of parameters and coefficients 
         which are supposed to be used when using the given function.
     **/
     
-    std::string m_fnct_name {};
+    std::string m_fct_name {};
     std::vector<std::string> m_pars {};
     std::vector<std::string> m_coefs {};
   };
   
-  using FnctLinkVec = std::vector<FnctLink>;
+  using FctLinkVec = std::vector<FctLink>;
 }
 }
 

--- a/source/prew/include/Data/PredLink.h
+++ b/source/prew/include/Data/PredLink.h
@@ -2,7 +2,7 @@
 #define LIB_PREDLINK_H 1
 
 #include <Data/DistrInfo.h>
-#include <Data/FnctLink.h>
+#include <Data/FctLink.h>
 
 #include <vector>
 
@@ -16,8 +16,8 @@ namespace Data {
     **/
 
     DistrInfo m_info {};
-    FnctLinkVec m_fncts_links_sig {}; // Modification of signal Xsection
-    FnctLinkVec m_fncts_links_bkg {}; // Modification of bkg Xsection 
+    FctLinkVec m_fcts_links_sig {}; // Modification of signal Xsection
+    FctLinkVec m_fcts_links_bkg {}; // Modification of bkg Xsection 
     
   };
   

--- a/source/prew/include/Fcts/FctMap.h
+++ b/source/prew/include/Fcts/FctMap.h
@@ -1,23 +1,23 @@
 #ifndef LIB_FNCTMAP_H
 #define LIB_FNCTMAP_H 1
 
-#include <Fncts/Physics.h>
-#include <Fncts/Polynomial.h>
-#include <Fncts/Statistic.h>
-#include <CppUtils/Fnct.h>
+#include <Fcts/Physics.h>
+#include <Fcts/Polynomial.h>
+#include <Fcts/Statistic.h>
+#include <CppUtils/Fct.h>
 
 #include <map>
 #include <string>
 
 namespace PREW {
-namespace Fncts {
+namespace Fcts {
   // Kind of map pointing from a string (function-ID) to a function 
   // which has three input parameter vectors: coordinate,parameters,coefficients
-  using FnctMap = std::map<std::string, CppUtils::Fnct::ParametrisationFnct>;
+  using FctMap = std::map<std::string, CppUtils::Fct::ParametrisationFct>;
         
   // This fixes the association of a funtion-ID string to an actual function.
   // All parameterisation functions must have their own unique ID!
-  static const FnctMap prew_fnct_map = {
+  static const FctMap prew_fct_map = {
     // Polynomials
     {"Constant", Polynomial::constant_par},
     {"Quadratic1DPolynomial", Polynomial::quadratic_1D},

--- a/source/prew/include/Fcts/Physics.h
+++ b/source/prew/include/Fcts/Physics.h
@@ -4,12 +4,12 @@
 #include <vector>
 
 namespace PREW {
-namespace Fncts {
+namespace Fcts {
   
 namespace Physics {
   /** Namespace for parametrisation functions from statistics.
       Must all follow structure:
-        double fnct_name (const std::vector<double>   &x,
+        double fct_name (const std::vector<double>   &x,
                           const std::vector<double>   &c,
                           const std::vector<double*>  &p);
   **/

--- a/source/prew/include/Fcts/Polynomial.h
+++ b/source/prew/include/Fcts/Polynomial.h
@@ -4,12 +4,12 @@
 #include <vector>
 
 namespace PREW {
-namespace Fncts {
+namespace Fcts {
   
 namespace Polynomial {
   /** Namespace for polynomial parametrisation functions.
       Must all follow structure:
-        double fnct_name (const std::vector<double>   &x,
+        double fct_name (const std::vector<double>   &x,
                           const std::vector<double>   &c,
                           const std::vector<double*>  &p);
   **/

--- a/source/prew/include/Fcts/Statistic.h
+++ b/source/prew/include/Fcts/Statistic.h
@@ -4,12 +4,12 @@
 #include <vector>
 
 namespace PREW {
-namespace Fncts {
+namespace Fcts {
   
 namespace Statistic {
   /** Namespace for parametrisation functions from statistics.
       Must all follow structure:
-        double fnct_name (const std::vector<double>   &x,
+        double fct_name (const std::vector<double>   &x,
                           const std::vector<double>   &c,
                           const std::vector<double*>  &p);
   **/

--- a/source/prew/include/ToyMeas/ToyGen.h
+++ b/source/prew/include/ToyMeas/ToyGen.h
@@ -16,20 +16,6 @@ namespace ToyMeas {
         their poissonian uncertainty.
     **/
     
-
-    // TODO 
-    // Similar to DataToFit
-    // Takes same input expect: No measurement & no output pointer
-    // => Creates its own internal FitContainer (with correctly connected FitBin predictions)
-    //      -> NOPE, needs to use combination of DiffDistrVec and ParVec instead because connection to DistrInfo still needed
-    // => Has function that creates vector DiffDistrVec in which predictions of FitBins are varied with Poissonian
-    // => Has function that can manipulate one of the FitPar values (by name of FitPar)
-    // TODO
-    
-    // TODO
-    // The function to create a toy distribution must take energy as input argument!
-    // TODO
-    
     // Provided as input
     Connect::DataConnector  m_connector {};
     Fit::ParVec             m_pars {};

--- a/source/prew/include/ToyMeas/ToyGen.h
+++ b/source/prew/include/ToyMeas/ToyGen.h
@@ -10,7 +10,7 @@
 namespace PREW { 
 namespace ToyMeas {
 
-  class ToyGenerator {
+  class ToyGen {
     /** Class that can create a toy measurements from generator level 
         distributions by fluctuating the expected number of events within 
         their poissonian uncertainty.
@@ -34,11 +34,11 @@ namespace ToyMeas {
     Connect::DataConnector  m_connector {};
     Fit::ParVec             m_pars {};
     
-    // Created by ToyGenerator: diff. distrs. from predictions
+    // Created by ToyGen: diff. distrs. from predictions
     Data::DiffDistrVec      m_diff_distrs {};
     
     public:
-      ToyGenerator(
+      ToyGen(
         const Connect::DataConnector & connector,
         const Fit::ParVec & pars
       );

--- a/source/prew/src/Connect/DataConnector.cpp
+++ b/source/prew/src/Connect/DataConnector.cpp
@@ -136,24 +136,24 @@ void DataConnector::fill_bins(
 
   // --- Get linkers for chiral alpha functions ------- ------------------------
   Connect::Linker linker_sig_LR = 
-    Connect::Linker(links_LR.m_fncts_links_sig, bin_centers, coefs_LR);
+    Connect::Linker(links_LR.m_fcts_links_sig, bin_centers, coefs_LR);
   Connect::Linker linker_bkg_LR = 
-    Connect::Linker(links_LR.m_fncts_links_bkg, bin_centers, coefs_LR);
+    Connect::Linker(links_LR.m_fcts_links_bkg, bin_centers, coefs_LR);
 
   Connect::Linker linker_sig_RL = 
-    Connect::Linker(links_RL.m_fncts_links_sig, bin_centers, coefs_RL);
+    Connect::Linker(links_RL.m_fcts_links_sig, bin_centers, coefs_RL);
   Connect::Linker linker_bkg_RL = 
-    Connect::Linker(links_RL.m_fncts_links_bkg, bin_centers, coefs_RL);
+    Connect::Linker(links_RL.m_fcts_links_bkg, bin_centers, coefs_RL);
 
   Connect::Linker linker_sig_LL = 
-    Connect::Linker(links_LL.m_fncts_links_sig, bin_centers, coefs_LL);
+    Connect::Linker(links_LL.m_fcts_links_sig, bin_centers, coefs_LL);
   Connect::Linker linker_bkg_LL = 
-    Connect::Linker(links_LL.m_fncts_links_bkg, bin_centers, coefs_LL);
+    Connect::Linker(links_LL.m_fcts_links_bkg, bin_centers, coefs_LL);
 
   Connect::Linker linker_sig_RR = 
-    Connect::Linker(links_RR.m_fncts_links_sig, bin_centers, coefs_RR);
+    Connect::Linker(links_RR.m_fcts_links_sig, bin_centers, coefs_RR);
   Connect::Linker linker_bkg_RR = 
-    Connect::Linker(links_RR.m_fncts_links_bkg, bin_centers, coefs_RR);
+    Connect::Linker(links_RR.m_fcts_links_bkg, bin_centers, coefs_RR);
   // ---------------------------------------------------------------------------
 
   // --- Get linkers for polarised alpha functions -----------------------------
@@ -161,9 +161,9 @@ void DataConnector::fill_bins(
   auto coefs_pol = Data::DistrUtils::subvec_pol(coefficients, pol_config);
 
   Connect::Linker linker_sig_pol = 
-    Connect::Linker(links_pol.m_fncts_links_sig, bin_centers, coefs_pol);
+    Connect::Linker(links_pol.m_fcts_links_sig, bin_centers, coefs_pol);
   Connect::Linker linker_bkg_pol = 
-    Connect::Linker(links_pol.m_fncts_links_bkg, bin_centers, coefs_pol);
+    Connect::Linker(links_pol.m_fcts_links_bkg, bin_centers, coefs_pol);
   // ---------------------------------------------------------------------------
 
   // --- Get polarisation factor alpha functions -------------------------------
@@ -188,10 +188,10 @@ void DataConnector::fill_bins(
     double sigma_sig_LL = pred_LL.m_sig_distr[bin];
     double sigma_sig_RR = pred_RR.m_sig_distr[bin];
 
-    auto alphas_sig_LR = linker_sig_LR.get_all_bonded_fncts_at_bin(bin, pars);
-    auto alphas_sig_RL = linker_sig_RL.get_all_bonded_fncts_at_bin(bin, pars);
-    auto alphas_sig_LL = linker_sig_LL.get_all_bonded_fncts_at_bin(bin, pars);
-    auto alphas_sig_RR = linker_sig_RR.get_all_bonded_fncts_at_bin(bin, pars);
+    auto alphas_sig_LR = linker_sig_LR.get_all_bonded_fcts_at_bin(bin, pars);
+    auto alphas_sig_RL = linker_sig_RL.get_all_bonded_fcts_at_bin(bin, pars);
+    auto alphas_sig_LL = linker_sig_LL.get_all_bonded_fcts_at_bin(bin, pars);
+    auto alphas_sig_RR = linker_sig_RR.get_all_bonded_fcts_at_bin(bin, pars);
 
     auto sigma_sig_LR_mod =
         LinkHelp::get_modified_sigma(sigma_sig_LR, alphas_sig_LR);
@@ -210,10 +210,10 @@ void DataConnector::fill_bins(
     double sigma_bkg_LL = pred_LL.m_bkg_distr[bin];
     double sigma_bkg_RR = pred_RR.m_bkg_distr[bin];
 
-    auto alphas_bkg_LR = linker_bkg_LR.get_all_bonded_fncts_at_bin(bin, pars);
-    auto alphas_bkg_RL = linker_bkg_RL.get_all_bonded_fncts_at_bin(bin, pars);
-    auto alphas_bkg_LL = linker_bkg_LL.get_all_bonded_fncts_at_bin(bin, pars);
-    auto alphas_bkg_RR = linker_bkg_RR.get_all_bonded_fncts_at_bin(bin, pars);
+    auto alphas_bkg_LR = linker_bkg_LR.get_all_bonded_fcts_at_bin(bin, pars);
+    auto alphas_bkg_RL = linker_bkg_RL.get_all_bonded_fcts_at_bin(bin, pars);
+    auto alphas_bkg_LL = linker_bkg_LL.get_all_bonded_fcts_at_bin(bin, pars);
+    auto alphas_bkg_RR = linker_bkg_RR.get_all_bonded_fcts_at_bin(bin, pars);
 
     auto sigma_bkg_LR_mod =
         LinkHelp::get_modified_sigma(sigma_bkg_LR, alphas_bkg_LR);
@@ -227,7 +227,7 @@ void DataConnector::fill_bins(
 
     // -------------------- Get polarised signal prediction --------------------
     spdlog::debug("Getting polarised signal predictions.");
-    auto alphas_sig_pol = linker_sig_pol.get_all_bonded_fncts_at_bin(bin, pars);
+    auto alphas_sig_pol = linker_sig_pol.get_all_bonded_fcts_at_bin(bin, pars);
 
     // No longer sigma because includes lumi => #Events
     auto pred_sig_pol =
@@ -248,7 +248,7 @@ void DataConnector::fill_bins(
 
     // -------------------- Get polarised background prediction ----------------
     spdlog::debug("Getting polarised background predictions.");
-    auto alphas_bkg_pol = linker_bkg_pol.get_all_bonded_fncts_at_bin(bin, pars);
+    auto alphas_bkg_pol = linker_bkg_pol.get_all_bonded_fcts_at_bin(bin, pars);
 
     // No longer sigma because includes lumi => #Events
     auto pred_bkg_pol =

--- a/source/prew/src/Connect/LinkHelp.cpp
+++ b/source/prew/src/Connect/LinkHelp.cpp
@@ -1,7 +1,7 @@
 #include <Connect/Linker.h>
 #include <Connect/LinkHelp.h>
 #include <Data/CoefDistr.h>
-#include <Data/FnctLink.h>
+#include <Data/FctLink.h>
 #include <GlobalVar/Chiral.h>
 
 namespace PREW {
@@ -50,7 +50,7 @@ std::function<double()> LinkHelp::get_polfactor_lambda(
   }
   
   // Instruction class for how to build lambda function
-  Data::FnctLinkVec pol_fnct_link {
+  Data::FctLinkVec pol_fct_link {
     {"PolarisationFactor", 
       {pol_link.get_eM_pol(), pol_link.get_eP_pol()}, // Parameters to use
       {eM_chirality,eP_chirality,"e-sign","e+sign"}   // Coefficients to use
@@ -59,8 +59,8 @@ std::function<double()> LinkHelp::get_polfactor_lambda(
     
   // Use Linker class to get function (Need one dummy 0 bin)
   auto pol_factor = 
-    Connect::Linker(pol_fnct_link, {{0}}, pol_coefs)
-    .get_bonded_fnct_at_bin("PolarisationFactor",0,pars);
+    Connect::Linker(pol_fct_link, {{0}}, pol_coefs)
+    .get_bonded_fct_at_bin("PolarisationFactor",0,pars);
 
   return pol_factor;
 }

--- a/source/prew/src/Fcts/Physics.cpp
+++ b/source/prew/src/Fcts/Physics.cpp
@@ -1,7 +1,7 @@
-#include <Fncts/Physics.h>
+#include <Fcts/Physics.h>
 
 namespace PREW {
-namespace Fncts {
+namespace Fcts {
 
 //------------------------------------------------------------------------------
 

--- a/source/prew/src/Fcts/Polynomial.cpp
+++ b/source/prew/src/Fcts/Polynomial.cpp
@@ -1,9 +1,9 @@
-#include <Fncts/Polynomial.h>
+#include <Fcts/Polynomial.h>
 
 #include <math.h>
 
 namespace PREW {
-namespace Fncts {
+namespace Fcts {
 
 //------------------------------------------------------------------------------
 

--- a/source/prew/src/Fcts/Statistic.cpp
+++ b/source/prew/src/Fcts/Statistic.cpp
@@ -1,10 +1,10 @@
-#include <Fncts/Statistic.h>
+#include <Fcts/Statistic.h>
 
 #include <exception>
 #include <math.h>
 
 namespace PREW {
-namespace Fncts {
+namespace Fcts {
 
 //------------------------------------------------------------------------------
 

--- a/source/prew/src/Input/Reading.cpp
+++ b/source/prew/src/Input/Reading.cpp
@@ -18,8 +18,8 @@ namespace Input {
 //------------------------------------------------------------------------------
 
 void Reading::read_RK_file(
-  const InputInfo *input_info, // TODO MAKE CONST
-  Data::PredDistrVec *pred_distrs, 
+  const InputInfo *input_info,
+  Data::PredDistrVec *pred_distrs,
   Data::CoefDistrVec *coef_distrs ) 
 {
   /** Read input file that is in style of Robert Karls root files.

--- a/source/prew/src/ToyMeas/ToyGen.cpp
+++ b/source/prew/src/ToyMeas/ToyGen.cpp
@@ -5,7 +5,7 @@
 #include <Data/DistrUtils.h>
 #include <GlobalVar/Chiral.h>
 #include <ToyMeas/Flct.h>
-#include <ToyMeas/ToyGenerator.h>
+#include <ToyMeas/ToyGen.h>
 
 #include "spdlog/spdlog.h"
 
@@ -19,7 +19,7 @@ namespace ToyMeas {
 //------------------------------------------------------------------------------
 // Constructors
 
-ToyGenerator::ToyGenerator(
+ToyGen::ToyGen(
   const Connect::DataConnector & connector,
   const Fit::ParVec & pars
 ) : m_connector(connector), m_pars(pars) 
@@ -114,7 +114,7 @@ ToyGenerator::ToyGenerator(
 //------------------------------------------------------------------------------
 // Functions to get distributions which were generated from predictions
 
-Data::DiffDistrVec ToyGenerator::get_expected_distrs ( int energy ) const {
+Data::DiffDistrVec ToyGen::get_expected_distrs ( int energy ) const {
   // TODO TODO TODO COMMENT!!!
   auto distrs = Data::DistrUtils::subvec_energy(m_diff_distrs, energy);
   
@@ -137,7 +137,7 @@ Data::DiffDistrVec ToyGenerator::get_expected_distrs ( int energy ) const {
   return output_distrs;
 }
 
-Data::DiffDistrVec ToyGenerator::get_fluctuated_distrs ( int energy ) const {
+Data::DiffDistrVec ToyGen::get_fluctuated_distrs ( int energy ) const {
   /** Get poisson fluctuated versions of the expected distributions at the given
       energy.
   **/

--- a/source/prew/src/ToyMeas/ToyGen.cpp
+++ b/source/prew/src/ToyMeas/ToyGen.cpp
@@ -126,25 +126,15 @@ Data::DiffDistrVec ToyGen::get_expected_distrs ( int energy ) const {
   // Get all distributions at the given energy
   auto distrs = Data::DistrUtils::subvec_energy(m_diff_distrs, energy);
   
-  // Create measured distributions for all distributions at that energy
-  Data::DiffDistrVec output_distrs {};
-  for ( const auto & distr: distrs ) {
-    Data::DiffDistr output_distr {
-      distr.m_info,
-      distr.m_bin_centers,
-      {} // Bin contents to be set now
-    };
-    
-    // Set the "measurement" to the prediction
-    for ( const auto & bin : distr.m_distribution ) {
-      output_distr.m_distribution.push_back(
-        Fit::FitBin(bin.get_val_prd(), std::sqrt(bin.get_val_prd()))
-      );
+  // Set the measuremed values to the predicted values (w/ poisson unc.)
+  for ( auto & distr: distrs ) {
+    for ( auto & bin : distr.m_distribution ) {
+      bin.set_val_mst( bin.get_val_prd() );
+      bin.set_val_unc( std::sqrt(bin.get_val_prd()) );
     }
-    output_distrs.push_back(output_distr);
   }
   
-  return output_distrs;
+  return distrs;
 }
 
 Data::DiffDistrVec ToyGen::get_fluctuated_distrs ( int energy ) const {

--- a/source/prew/src/ToyMeas/ToyGen.cpp
+++ b/source/prew/src/ToyMeas/ToyGen.cpp
@@ -24,7 +24,11 @@ ToyGen::ToyGen(
   const Fit::ParVec & pars
 ) : m_connector(connector), m_pars(pars) 
 {
-  // TODO DESCRIPTION!!!
+  /** Toy generator constructor sets up the distributions with linked 
+      predictions for every predicted distribution in the connector.
+      These linked predictions are later used to create toy measurements by
+      fluctuating the prediction in each bin.
+  **/
   
   if (m_connector.get_pred_distrs().size() == 0) {
     spdlog::warn("No predicted distributions supplied!");
@@ -58,7 +62,6 @@ ToyGen::ToyGen(
   
   // Check what was found
   for (const int & energy: energies) {
-    // TODO Map function to check if element exists TODO
     if (pol_configs_per_energies.find(energy)==pol_configs_per_energies.end()) {
       spdlog::warn("For E={} no pol. config. found!", energy);
       continue;
@@ -115,9 +118,15 @@ ToyGen::ToyGen(
 // Functions to get distributions which were generated from predictions
 
 Data::DiffDistrVec ToyGen::get_expected_distrs ( int energy ) const {
-  // TODO TODO TODO COMMENT!!!
+  /** Return all predicted distributions at the given energy as measured 
+      distributions:
+        - measured value = prediction
+        - uncertainty = square-root of the prediction
+  **/
+  // Get all distributions at the given energy
   auto distrs = Data::DistrUtils::subvec_energy(m_diff_distrs, energy);
   
+  // Create measured distributions for all distributions at that energy
   Data::DiffDistrVec output_distrs {};
   for ( const auto & distr: distrs ) {
     Data::DiffDistr output_distr {
@@ -126,6 +135,7 @@ Data::DiffDistrVec ToyGen::get_expected_distrs ( int energy ) const {
       {} // Bin contents to be set now
     };
     
+    // Set the "measurement" to the prediction
     for ( const auto & bin : distr.m_distribution ) {
       output_distr.m_distribution.push_back(
         Fit::FitBin(bin.get_val_prd(), std::sqrt(bin.get_val_prd()))
@@ -141,6 +151,7 @@ Data::DiffDistrVec ToyGen::get_fluctuated_distrs ( int energy ) const {
   /** Get poisson fluctuated versions of the expected distributions at the given
       energy.
   **/
+  // Get the distributions at this energy (with measurement = prediction)
   Data::DiffDistrVec distrs = this->get_expected_distrs(energy);
   
   // Fluctuate each bin with a Poisson distribution on its value and adjust unc.

--- a/source/tests/Connect/test_Linker.cpp
+++ b/source/tests/Connect/test_Linker.cpp
@@ -2,7 +2,7 @@
 #include <CppUtils/Num.h>
 #include <CppUtils/Vec.h>
 #include <Data/CoefDistr.h>
-#include <Data/FnctLink.h>
+#include <Data/FctLink.h>
 #include <Fit/FitPar.h>
 
 #include <gtest/gtest.h>
@@ -38,7 +38,7 @@ TEST(TestLinker, GaussianTest) {
   };
   
   // --- Instructions on how to connect to prediction:
-  FnctLinkVec fnct_links {
+  FctLinkVec fct_links {
     {"Gaussian1D", // Only one function here: Gaussian
       {"A","mu","sigma"}, // Parameter map
       {} // Coefficient map
@@ -46,13 +46,13 @@ TEST(TestLinker, GaussianTest) {
   };
   
   // --- Get functions from linker which are linked to parameters
-  Linker linker = Linker(fnct_links, bin_centers, coefs);
+  Linker linker = Linker(fct_links, bin_centers, coefs);
   
-  auto gaussian_bin0 = linker.get_bonded_fnct_at_bin("Gaussian1D",0,&pars);
-  auto gaussian_bin1 = linker.get_bonded_fnct_at_bin("Gaussian1D",1,&pars);
-  auto gaussian_bin2 = linker.get_bonded_fnct_at_bin("Gaussian1D",2,&pars);
-  auto gaussian_bin3 = linker.get_bonded_fnct_at_bin("Gaussian1D",3,&pars);
-  auto gaussian_bin4 = linker.get_bonded_fnct_at_bin("Gaussian1D",4,&pars);
+  auto gaussian_bin0 = linker.get_bonded_fct_at_bin("Gaussian1D",0,&pars);
+  auto gaussian_bin1 = linker.get_bonded_fct_at_bin("Gaussian1D",1,&pars);
+  auto gaussian_bin2 = linker.get_bonded_fct_at_bin("Gaussian1D",2,&pars);
+  auto gaussian_bin3 = linker.get_bonded_fct_at_bin("Gaussian1D",3,&pars);
+  auto gaussian_bin4 = linker.get_bonded_fct_at_bin("Gaussian1D",4,&pars);
   
   // --- Check (changing) function output
   // Looked up exact expected values in WolframAlpha -> compare
@@ -102,7 +102,7 @@ TEST(TestLinker, GaussianManyValuesTest) {
   };
   
   // --- Instructions on how to connect to prediction:
-  FnctLinkVec fnct_links {
+  FctLinkVec fct_links {
     {"Gaussian1D", // Only one function here: Gaussian
       {"A","mu","sigma"}, // Parameter map
       {} // Coefficient map
@@ -110,13 +110,13 @@ TEST(TestLinker, GaussianManyValuesTest) {
   };
   
   // --- Get functions from linker which are linked to parameters
-  Linker linker = Linker(fnct_links, bin_centers, coefs);
+  Linker linker = Linker(fct_links, bin_centers, coefs);
   
   // Get all bin functions
   std::vector<std::function<double()>> gaussian_at_bins {};
   for (int bin=0; bin<bin_centers.size(); bin++) {
     gaussian_at_bins.push_back(
-      linker.get_bonded_fnct_at_bin("Gaussian1D",bin,&pars)
+      linker.get_bonded_fct_at_bin("Gaussian1D",bin,&pars)
     );
   }
   
@@ -164,18 +164,18 @@ TEST(TestLinker, MultiFunctionTest) {
   };
   
   // --- Instructions on how to connect to prediction:
-  FnctLinkVec fnct_links {
+  FctLinkVec fct_links {
     {"Gaussian1D", {"P1","mu","sigma"}, {}},
     {"Quadratic1DPolynomial", {"P1","P2","P3"}, {}} // Notice P1 overlap!
   };
   
   // --- Get functions from linker which are linked to parameters
-  Linker linker = Linker(fnct_links, bin_centers, coefs);
-  auto all_bin_fncts = linker.get_all_bonded_fncts_at_bin(0,&pars);
-  ASSERT_EQ( all_bin_fncts.size(), 2 );
+  Linker linker = Linker(fct_links, bin_centers, coefs);
+  auto all_bin_fcts = linker.get_all_bonded_fcts_at_bin(0,&pars);
+  ASSERT_EQ( all_bin_fcts.size(), 2 );
   
-  auto gaussian_bin  = all_bin_fncts.at(0);
-  auto quadratic_bin = all_bin_fncts.at(1);
+  auto gaussian_bin  = all_bin_fcts.at(0);
+  auto quadratic_bin = all_bin_fcts.at(1);
 
   // --- Check for expected output
   ASSERT_EQ(Num::equal_to_eps(gaussian_bin(), 0.3989422804, 1e-9), true)

--- a/source/tests/Fncts/test_Physics.cpp
+++ b/source/tests/Fncts/test_Physics.cpp
@@ -1,12 +1,12 @@
 #include <CppUtils/Num.h>
-#include <Fncts/Physics.h>
+#include <Fcts/Physics.h>
 
 #include <gtest/gtest.h>
 
 #include <vector>
 
 using namespace PREW::CppUtils;
-using namespace PREW::Fncts;
+using namespace PREW::Fcts;
 
 //------------------------------------------------------------------------------
 // Check that polynomial functions are correctly implemented

--- a/source/tests/Fncts/test_Polynomial.cpp
+++ b/source/tests/Fncts/test_Polynomial.cpp
@@ -1,12 +1,12 @@
 #include <CppUtils/Num.h>
-#include <Fncts/Polynomial.h>
+#include <Fcts/Polynomial.h>
 
 #include <gtest/gtest.h>
 
 #include <vector>
 
 using namespace PREW::CppUtils;
-using namespace PREW::Fncts;
+using namespace PREW::Fcts;
 
 //------------------------------------------------------------------------------
 // Check that polynomial functions are correctly implemented

--- a/source/tests/Fncts/test_Statistic.cpp
+++ b/source/tests/Fncts/test_Statistic.cpp
@@ -1,12 +1,12 @@
 #include <CppUtils/Num.h>
-#include <Fncts/Statistic.h>
+#include <Fcts/Statistic.h>
 
 #include <gtest/gtest.h>
 
 #include <vector>
 
 using namespace PREW::CppUtils;
-using namespace PREW::Fncts;
+using namespace PREW::Fcts;
 
 //------------------------------------------------------------------------------
 // Check that statistical functions are correctly implemented

--- a/source/tests/ToyMeas/test_ToyGen.cpp
+++ b/source/tests/ToyMeas/test_ToyGen.cpp
@@ -7,7 +7,7 @@
 #include <Data/PolLink.h>
 #include <Fit/FitPar.h>
 #include <GlobalVar/Chiral.h>
-#include <ToyMeas/ToyGenerator.h>
+#include <ToyMeas/ToyGen.h>
 
 #include <gtest/gtest.h>
 #include "spdlog/spdlog.h"
@@ -22,7 +22,7 @@ using namespace PREW::ToyMeas;
 //------------------------------------------------------------------------------
 // Check that statistical functions are correctly implemented
 
-TEST(TestToyGenerator, SimpleConstructor) {
+TEST(TestToyGen, SimpleConstructor) {
   /** Copy-paste of DataConnector test with slightly varied values,
       tests that bin predicitions are in the end properly transformed into bin
       content of a faked differential distribution.
@@ -61,7 +61,7 @@ TEST(TestToyGenerator, SimpleConstructor) {
   
   DataConnector connector {pred_distrs,coef_distrs,pred_links,pol_links};
   
-  ToyGenerator test_gen = ToyGenerator( connector, input_pars );
+  ToyGen test_gen = ToyGen( connector, input_pars );
                 
   // Do I get correctly sized distributions?
   auto expected_distrs = test_gen.get_expected_distrs(500);


### PR DESCRIPTION
- Unify notation by renaming everything that contains fnct (function) to fct.
- Rename ToyGenerator to ToyGen for shorter naming.
- Clean up and sort out old TODOs mostly related to proper commenting.
- Simplify how expected distributions are gotten in ToyGen by using new set functions of FitBin class.