### PR TITLE
Add measurement realism

### DIFF
--- a/source/prew/include/CppUtils/Vec.tpp
+++ b/source/prew/include/CppUtils/Vec.tpp
@@ -3,6 +3,8 @@
 
 #include <CppUtils/Vec.h>
 
+#include <algorithm>
+
 namespace PREW {
 namespace CppUtils {
 

--- a/source/prew/include/Fcts/FctMap.h
+++ b/source/prew/include/Fcts/FctMap.h
@@ -26,7 +26,8 @@ namespace Fcts {
     // Statisticals
     {"Gaussian1D", Statistic::gaussian_1D},
     // Physis motivated
-    {"PolarisationFactor", Physics::polarisation_factor}
+    {"PolarisationFactor", Physics::polarisation_factor},
+    {"LuminosityFraction", Physics::luminosity_fraction}
   };
 
   

--- a/source/prew/include/Fcts/FctMap.h
+++ b/source/prew/include/Fcts/FctMap.h
@@ -22,6 +22,7 @@ namespace Fcts {
     {"Constant", Polynomial::constant_par},
     {"ConstantCoef", Polynomial::constant_coef},
     {"Quadratic1DPolynomial", Polynomial::quadratic_1D},
+    {"Quadratic3DPolynomial_Coeff", Polynomial::quadratic_3D_coeff},
     // Statisticals
     {"Gaussian1D", Statistic::gaussian_1D},
     // Physis motivated

--- a/source/prew/include/Fcts/FctMap.h
+++ b/source/prew/include/Fcts/FctMap.h
@@ -20,6 +20,7 @@ namespace Fcts {
   static const FctMap prew_fct_map = {
     // Polynomials
     {"Constant", Polynomial::constant_par},
+    {"ConstantCoef", Polynomial::constant_coef},
     {"Quadratic1DPolynomial", Polynomial::quadratic_1D},
     // Statisticals
     {"Gaussian1D", Statistic::gaussian_1D},

--- a/source/prew/include/Fcts/Physics.h
+++ b/source/prew/include/Fcts/Physics.h
@@ -17,6 +17,10 @@ namespace Physics {
   double polarisation_factor (const std::vector<double>   &x,
                               const std::vector<double>   &c,
                               const std::vector<double*>  &p);
+  
+  double luminosity_fraction (const std::vector<double>   &x,
+                              const std::vector<double>   &c,
+                              const std::vector<double*>  &p);
 }
   
 }

--- a/source/prew/include/Fcts/Polynomial.h
+++ b/source/prew/include/Fcts/Polynomial.h
@@ -26,6 +26,10 @@ namespace Polynomial {
                         const std::vector<double>   &c,
                         const std::vector<double*>  &p);
                         
+  double quadratic_3D_coeff ( const std::vector<double>   &x,
+                              const std::vector<double>   &c,
+                              const std::vector<double*>  &p);
+                        
 }
   
 }

--- a/source/prew/include/Fcts/Polynomial.h
+++ b/source/prew/include/Fcts/Polynomial.h
@@ -14,6 +14,10 @@ namespace Polynomial {
                           const std::vector<double*>  &p);
   **/
   
+  double constant_coef ( const std::vector<double>   &x,
+                         const std::vector<double>   &c,
+                         const std::vector<double*>  &p);
+  
   double constant_par ( const std::vector<double>   &x,
                         const std::vector<double>   &c,
                         const std::vector<double*>  &p);

--- a/source/prew/src/Fcts/Physics.cpp
+++ b/source/prew/src/Fcts/Physics.cpp
@@ -26,5 +26,22 @@ double Physics::polarisation_factor (
         ( 1 + c[1] * c[3] * (*(p[1])) );
 }
 
+//------------------------------------------------------------------------------
+
+double Physics::luminosity_fraction ( 
+  const std::vector<double> &/*x*/,
+  const std::vector<double> &c,
+  const std::vector<double*> &p
+) {
+  /** Calculate the fraction of the luminosity.
+      Coefficients: c[0] - luminosity fraction
+      Parameters: p[0] - total luminosity
+  **/
+  
+  return c[0] * (*(p[0]));
+}
+
+//------------------------------------------------------------------------------
+
 }
 }

--- a/source/prew/src/Fcts/Polynomial.cpp
+++ b/source/prew/src/Fcts/Polynomial.cpp
@@ -39,7 +39,7 @@ double Polynomial::quadratic_1D (
   const std::vector<double> &/*c*/,
   const std::vector<double*> &p
 ) {
-  /** Gaussian function in 1D.
+  /** Quadratic polynomial in x (1D coordinate) with parameters as constants.
       Parameters: p[0] - offset
                   p[1] - linear coeff
                   p[2] - quadratic coeff

--- a/source/prew/src/Fcts/Polynomial.cpp
+++ b/source/prew/src/Fcts/Polynomial.cpp
@@ -7,6 +7,19 @@ namespace Fcts {
 
 //------------------------------------------------------------------------------
 
+double Polynomial::constant_coef ( 
+  const std::vector<double>   &/*x*/,
+  const std::vector<double>   &c,
+  const std::vector<double*>  &/*p*/
+) {
+  /** Simple constant factor, no variation with parameters.
+      Can be used to scale cross sections.
+  **/
+  return c[0];
+}
+
+//------------------------------------------------------------------------------
+
 double Polynomial::constant_par ( 
   const std::vector<double>   &/*x*/,
   const std::vector<double>   &/*c*/,

--- a/source/prew/src/Fcts/Polynomial.cpp
+++ b/source/prew/src/Fcts/Polynomial.cpp
@@ -51,5 +51,28 @@ double Polynomial::quadratic_1D (
 
 //------------------------------------------------------------------------------
 
+double Polynomial::quadratic_3D_coeff ( 
+  const std::vector<double> &/*x*/,
+  const std::vector<double> &c,
+  const std::vector<double*> &p
+) {
+  /** Cubic polynomial in 1D.
+      Parameters: p[0-2] - variables of polynomial
+      Coefficients: c[0] - offset
+                    c[1-3] - linear coeffs
+                    c[4-6] - pure quadratic coeff
+                    c[7-9] - mixed quadratic coeff
+  **/
+  
+  return  c[0]
+          + c[1]* (*(p[0])) + c[2]* (*(p[1])) + c[3]* (*(p[2]))
+          + c[4]* std::pow((*(p[0])),2) + c[5]* std::pow((*(p[1])),2) 
+                                        + c[6]* std::pow((*(p[2])),2)
+          + c[7]* (*(p[0])) * (*(p[1])) + c[8]* (*(p[0])) * (*(p[2])) 
+                                        + c[9]* (*(p[1])) * (*(p[2]));
+}
+
+//------------------------------------------------------------------------------
+
 }
 }

--- a/source/prew/src/Input/Reading.cpp
+++ b/source/prew/src/Input/Reading.cpp
@@ -114,10 +114,16 @@ void Reading::read_RK_file(
     size_t n_coefs = coef_labels.size();
     
     Data::CoefDistrVec coefs_LL (n_coefs), coefs_LR (n_coefs), coefs_RL (n_coefs), coefs_RR (n_coefs);
-    for (auto & coef: coefs_LL) { coef.m_info = info_LL; }
-    for (auto & coef: coefs_LR) { coef.m_info = info_LR; }
-    for (auto & coef: coefs_RL) { coef.m_info = info_RL; }
-    for (auto & coef: coefs_RR) { coef.m_info = info_RR; }
+    for (size_t c=0; c<n_coefs; c++) { 
+      coefs_LL[c].m_coef_name = coef_labels[c];
+      coefs_LR[c].m_coef_name = coef_labels[c];
+      coefs_RL[c].m_coef_name = coef_labels[c];
+      coefs_RR[c].m_coef_name = coef_labels[c];
+      coefs_LL[c].m_info = info_LL;
+      coefs_LR[c].m_info = info_LR;
+      coefs_RL[c].m_info = info_RL;
+      coefs_RR[c].m_info = info_RR;
+    }
     
     for (int bin=0; bin<n_bins; bin++) {
       pred_LL.m_sig_distr.push_back( diff_sigma_signal_LL[bin] );

--- a/source/tests/Fncts/test_Physics.cpp
+++ b/source/tests/Fncts/test_Physics.cpp
@@ -34,4 +34,18 @@ TEST(TestPhysics, PolarisationFactor) {
     << " got " << Physics::polarisation_factor({},c,p_ptrs);
 }
 
+TEST(TestPhysics, LuminosityFraction) {
+  // Test the luminosity fraction function.
+  std::vector<double> c { 0.25 };
+  std::vector<double> p_vals { 2000 };
+  std::vector<double*> p_ptrs {};
+  for (double & p: p_vals) { p_ptrs.push_back(&p); }
+  
+  ASSERT_EQ( 
+    Num::equal_to_eps( Physics::luminosity_fraction({},c,p_ptrs), 500.0, 1e-9), 
+    true 
+  ) << "Expected " << 500.0
+    << " got " << Physics::luminosity_fraction({},c,p_ptrs);
+}
+
 //------------------------------------------------------------------------------

--- a/source/tests/Fncts/test_Polynomial.cpp
+++ b/source/tests/Fncts/test_Polynomial.cpp
@@ -72,4 +72,18 @@ TEST(TestPolynomial, Gaussian1D) {
     << " got " << Polynomial::quadratic_1D({1.5},c,p_ptrs);
 }
 
+TEST(TestPolynomial, Quadratic3DCoeff) {
+  // Test 3D quadratic function that includes mixed terms
+  std::vector<double> c {1.0, 2.0, -2.0, 2.0, -0.5, 0.5, -0.5, 1.5, 2, 2.5};
+  std::vector<double> p_vals { 1.0, 3.0, 4.0 };
+  std::vector<double*> p_ptrs {};
+  for (double & p: p_vals) { p_ptrs.push_back(&p); }
+
+  ASSERT_EQ( 
+    Num::equal_to_eps( Polynomial::quadratic_3D_coeff({},c,p_ptrs), 43.5, 1e-9), 
+    true 
+  ) << "Expected " << 43.5 
+    << " got " << Polynomial::quadratic_3D_coeff({},c,p_ptrs);
+}
+
 //------------------------------------------------------------------------------

--- a/source/tests/Fncts/test_Polynomial.cpp
+++ b/source/tests/Fncts/test_Polynomial.cpp
@@ -41,7 +41,7 @@ TEST(TestPolynomial, ConstantCoef) {
   ) << "Expected " << -2.5 << " got " << Polynomial::constant_par({},c,{});
 }
 
-TEST(TestPolynomial, Gaussian1D) {
+TEST(TestPolynomial, Quadratic1D) {
   std::vector<double> c {};
   std::vector<double> p_vals {  1.0, // Offset
                                 2.0, // Linear parameter

--- a/source/tests/Fncts/test_Polynomial.cpp
+++ b/source/tests/Fncts/test_Polynomial.cpp
@@ -32,6 +32,15 @@ TEST(TestPolynomial, ConstantPar) {
   ) << "Expected " << 2000. << " got " << Polynomial::constant_par({},c,p_ptrs);
 }
 
+TEST(TestPolynomial, ConstantCoef) {
+  // Test function that simply mirrors the parameter
+  std::vector<double> c {-2.5};
+
+  ASSERT_EQ( 
+    Num::equal_to_eps( Polynomial::constant_coef({},c,{}), -2.5, 1e-9), true 
+  ) << "Expected " << -2.5 << " got " << Polynomial::constant_par({},c,{});
+}
+
 TEST(TestPolynomial, Gaussian1D) {
   std::vector<double> c {};
   std::vector<double> p_vals {  1.0, // Offset

--- a/source/tests/Input/test_DataReader.cpp
+++ b/source/tests/Input/test_DataReader.cpp
@@ -47,6 +47,12 @@ TEST(TestDataReader, TestRKFileReading) {
     for (const auto & bin: pred.m_bkg_distr) { sum_bkg += bin; }
     ASSERT_EQ(sum_bkg, 0.0) << "RK style file should not contain bkg.";
   }
+  
+  // Check that all coefficients are named
+  for (const auto & coef: prediction_coefficients) {
+    ASSERT_EQ( (coef.m_coef_name == ""), false );
+  }
+
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
- Fix bug in reading of RK style file in which coefficients did not get a name assigned to them.
- Adjust test of RK style file reading to test that coef names are not empty.
- Add function to polynomial namespace that simply returns the given coefficient.
- Add const coeff function to function map.
- Add test of const coeff function.
- Add polynomial 3D function where coefficients give constants and parameters are function variable.
- Add polynomial 3D function to function map.
- Add test for 3D polynomial function.
- Fix buggy documentation of quadratic polynomial where it was still named Gaussian in docu and test.
- Add luminosity fraction to physics function namespace.
- Add luminosity fraction function to function map.
- Add test for luminosity fraction function.
- Add missing algorithm include to Vec template file.