### PR TITLE
Add output framework 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /external/*
 /build
 *.root
+/source/prout/__pycache__

--- a/Readme.md
+++ b/Readme.md
@@ -48,3 +48,29 @@ The rest of the `PrEW` framework is dedicated to setting up the components for t
 The current usage of `PrEW` framework itself is still quite complicated.
 It is recommended to use classes provided in the `PrEWUtils` package.
 An example for such a usage is provided in the `PrEWRunRK` package.
+ 
+## PrOut
+
+`PrEW` contains a `Python` module called `PrOut` that provides classes for the interpretation of fit output files.
+
+
+### Usage
+
+The module can be loaded into a python script using
+```Py
+import sys
+sys.path.append("INSERT_YOUR_PrEW_PATH/source/prout")
+import PrOut
+```
+(wherein the correct path to your PrEW installation need to be set).
+
+The module classes can be used to interpret an output file and read them into python class objects.
+
+```Py
+reader = PrOut.Reader("your_PrEW_output_file.out")
+reader.read()
+results = reader.run_results
+```
+For details on the result class objects please see the `PrOut` source code.
+ 
+ 

--- a/Readme.md
+++ b/Readme.md
@@ -30,3 +30,21 @@
  cd macros && chmod u+x compile.sh && ./compile.sh && cd ..
  ```
  The compilation can also be done in multithreaded mode using `./compile.sh --jobs=N_jobs`.
+ 
+ 
+### Idea
+
+`PrEW` was developed on the idea to decouple the core computing-heavy chi-squared minimization from the complex and complicated formulation of bin predictions for observable distributions at e+e- colliders.
+
+A core fitting framework provides a fast and general way to fit a parameter-dependent prediction to a large number of bins. 
+This core has no knowledge of the physics and must be provided with the measured bin values, parameters, and the bin prediction functions. 
+The latter describe how the prediction of the bin depends on the parameters.
+With those components available, a chi-squared minimization is performed using the `ROOT::Minuit2` framework.
+
+The rest of the `PrEW` framework is dedicated to setting up the components for the core fit from human-readable physics instructions provided by the user.
+
+### Usage
+
+The current usage of `PrEW` framework itself is still quite complicated.
+It is recommended to use classes provided in the `PrEWUtils` package.
+An example for such a usage is provided in the `PrEWRunRK` package.

--- a/source/prew/include/CppUtils/Str.h
+++ b/source/prew/include/CppUtils/Str.h
@@ -10,9 +10,14 @@ namespace CppUtils {
 namespace Str {
   std::vector<std::string> string_to_vec( const std::string &str, 
                                           std::string delimiter=" ");
+  
+  template<class T>          
+  std::string sci_string(T number, int precision=7);
 }
 
 }
 }
+
+#include <CppUtils/Str.tpp>
 
 #endif

--- a/source/prew/include/CppUtils/Str.h
+++ b/source/prew/include/CppUtils/Str.h
@@ -13,6 +13,8 @@ namespace Str {
   
   template<class T>          
   std::string sci_string(T number, int precision=7);
+  
+  std::string get_dir_path_str( const std::string & file_path );
 }
 
 }

--- a/source/prew/include/CppUtils/Str.tpp
+++ b/source/prew/include/CppUtils/Str.tpp
@@ -1,0 +1,30 @@
+#ifndef LIB_CPPHELPSTR_TPP
+#define LIB_CPPHELPSTR_TPP 1
+
+#include <CppUtils/Str.h>
+
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+namespace PREW {
+namespace CppUtils {
+  
+template<class T>          
+std::string Str::sci_string(T number, int precision){
+  /** Return a string of the given number in scientific notation.
+  **/
+  std::ostringstream stream;
+ 
+  // Switch to scientific notation with given precision and add double to stream
+  stream << std::scientific << std::setprecision(precision) << number;
+   
+  // Get string from output string stream
+  return stream.str(); 
+}
+
+}
+}
+
+#endif

--- a/source/prew/include/CppUtils/Sys.h
+++ b/source/prew/include/CppUtils/Sys.h
@@ -8,7 +8,7 @@ namespace CppUtils {
 
 namespace Sys {
   
-  bool file_exists (const std::string& file_path);
+  bool path_exists (const std::string& file_path);
 
 }
 

--- a/source/prew/include/CppUtils/Sys.h
+++ b/source/prew/include/CppUtils/Sys.h
@@ -9,6 +9,7 @@ namespace CppUtils {
 namespace Sys {
   
   bool path_exists (const std::string& file_path);
+  bool file_writable(const std::string& file_path);
 
 }
 

--- a/source/prew/include/Fit/FitResult.h
+++ b/source/prew/include/Fit/FitResult.h
@@ -23,6 +23,7 @@ namespace Fit {
     bool operator!=(const FitResult& result) const;
   };
   
+  using ResultVec = std::vector<Fit::FitResult>;
 }
 }
 

--- a/source/prew/include/Fit/FitResult.tpp
+++ b/source/prew/include/Fit/FitResult.tpp
@@ -1,6 +1,7 @@
 #ifndef LIB_FITRESULT_TPP
 #define LIB_FITRESULT_TPP 1
 
+#include <CppUtils/Str.h>
 #include <Fit/FitResult.h>
 
 #include "spdlog/fmt/ostr.h" // To allow output with spdlog
@@ -12,14 +13,16 @@ OStream& operator<<(OStream& os, const PREW::Fit::FitResult& fr) {
   /** Define what happens if a stream operator is called on the FitResult class.
       (e.g. like `std::cout << fit_result;`)
   **/
+  using namespace PREW; // CppUtils::Str
+  
   std::string output {};
   output.append("Parameters:\n");
   for (size_t par=0;par<fr.m_par_names.size();par++) {
     output.append(
       "p"  + std::to_string(par) 
       + " : " + fr.m_par_names.at(par)
-      + " = " + std::to_string(fr.m_pars_fin.at(par)) 
-      + " +- " + std::to_string(fr.m_uncs_fin.at(par))
+      + " = " + CppUtils::Str::sci_string(fr.m_pars_fin.at(par)) 
+      + " +- " + CppUtils::Str::sci_string(fr.m_uncs_fin.at(par))
       + "\n"
     ) ;  
   }
@@ -35,7 +38,10 @@ OStream& operator<<(OStream& os, const PREW::Fit::FitResult& fr) {
   for (size_t par1=0;par1<fr.m_cov_matrix.size();par1++) {
     output.append("p" + std::to_string(par1) + "    ");
     for (size_t par2=0;par2<fr.m_cov_matrix[par1].size();par2++) {
-      output.append(std::to_string(fr.m_cov_matrix[par1][par2]) + "  ");
+      // Covariance matrix needs scientific string notation due to small values
+      output.append(
+        CppUtils::Str::sci_string(fr.m_cov_matrix[par1][par2]) + "  "
+      );
     }
     output.append("\n");
   }
@@ -51,15 +57,17 @@ OStream& operator<<(OStream& os, const PREW::Fit::FitResult& fr) {
   for (size_t par1=0;par1<fr.m_cor_matrix.size();par1++) {
     output.append("p" + std::to_string(par1) + "    ");
     for (size_t par2=0;par2<fr.m_cor_matrix[par1].size();par2++) {
-      output.append(std::to_string(fr.m_cor_matrix[par1][par2]) + "  ");
+      output.append(
+        CppUtils::Str::sci_string(fr.m_cor_matrix[par1][par2]) + "  "
+      );
     }
     output.append("\n");
   }
   output.append("\n");
 
   output.append("Fit quality measures:\n");
-  output.append("Chi^2 = " + std::to_string(fr.m_chisq_fin) + "\n");
-  output.append("EDM   = " + std::to_string(fr.m_edm_fin) + "\n");
+  output.append("Chi^2 = " + CppUtils::Str::sci_string(fr.m_chisq_fin) + "\n");
+  output.append("EDM   = " + CppUtils::Str::sci_string(fr.m_edm_fin) + "\n");
   output.append("Cov. matrix status : " + std::to_string(fr.m_cov_status));
   
   // Feed the output string into the given stream

--- a/source/prew/include/Output/Printer.h
+++ b/source/prew/include/Output/Printer.h
@@ -1,0 +1,59 @@
+#ifndef LIB_PRINTER_H
+#define LIB_PRINTER_H 1
+
+#include <Connect/DataConnector.h>
+#include <Fit/FitResult.h>
+
+#include <string>
+
+namespace PREW {
+namespace Output {
+  
+  class Printer {
+    /** Class to print the information and results from fits to a file.
+        TODO 
+        Currently restricted to results of fit, distribution writing not 
+        yet available.
+        TODO
+    **/
+    
+    // Input arguments
+    std::string m_file_path {}; // Path of the output file
+    
+    // Internal strings to collect complete output before writing it
+    std::string m_info_str {};  // String for input information
+    std::string m_res_str {};   // String for fit results 
+    
+    std::string m_compl_setups {}; // String to collect completed setup outputs
+    
+    // Tracking number of fit results
+    int m_n_fits {};
+    
+    // Internal functions defining actual output
+    void add_meta_info(int energy, const Connect::DataConnector & connector);
+    void add_par_info(const Fit::FitResult & result);
+    void add_fit_res(const Fit::FitResult & result);
+    std::string assemble_setup_output() const;
+    
+    // Internal functions to handle output
+    bool has_setup_to_save() const;
+    void save_setup_output();
+    void reset_setup();
+
+    public:
+      // Constructors
+      Printer( std::string file_path );
+
+      // Writing functions
+      void new_setup( int energy, const Connect::DataConnector & connector );
+      void add_fit( const Fit::FitResult & result );
+      void write( const std::string & mode="overwrite" ) const;
+
+      // Functions to check current status
+      std::string get_current_output() const;
+  };
+  
+}
+}
+
+#endif

--- a/source/prew/include/Output/Printer.h
+++ b/source/prew/include/Output/Printer.h
@@ -47,6 +47,7 @@ namespace Output {
       // Writing functions
       void new_setup( int energy, const Connect::DataConnector & connector );
       void add_fit( const Fit::FitResult & result );
+      void add_fits( const Fit::ResultVec & results );
       void write( const std::string & mode="overwrite" ) const;
 
       // Functions to check current status

--- a/source/prew/src/CppUtils/Str.cpp
+++ b/source/prew/src/CppUtils/Str.cpp
@@ -5,7 +5,6 @@ namespace CppUtils {
 
 //------------------------------------------------------------------------------
 
-
 std::vector<std::string> Str::string_to_vec( 
   const std::string &str, 
   std::string delimiter ) 
@@ -27,6 +26,13 @@ std::vector<std::string> Str::string_to_vec(
   return substrings;
 }
 
+//------------------------------------------------------------------------------
+
+std::string Str::get_dir_path_str( const std::string & file_path ) {
+  /** Get part of file path string that describes the directory path.
+  **/
+  return file_path.substr(0,file_path.find_last_of("/\\"));
+}
 
 //------------------------------------------------------------------------------
   

--- a/source/prew/src/CppUtils/Str.cpp
+++ b/source/prew/src/CppUtils/Str.cpp
@@ -31,7 +31,9 @@ std::vector<std::string> Str::string_to_vec(
 std::string Str::get_dir_path_str( const std::string & file_path ) {
   /** Get part of file path string that describes the directory path.
   **/
-  return file_path.substr(0,file_path.find_last_of("/\\"));
+  std::string dir_path = file_path.substr(0,file_path.find_last_of("/\\"));
+  if ( dir_path == file_path ) { dir_path = ""; }
+  return dir_path;
 }
 
 //------------------------------------------------------------------------------

--- a/source/prew/src/CppUtils/Sys.cpp
+++ b/source/prew/src/CppUtils/Sys.cpp
@@ -1,7 +1,11 @@
+#include <CppUtils/Str.h>
 #include <CppUtils/Sys.h>
 
+#include <fstream>
+#include <stdexcept>
 #include <string>
 #include <sys/stat.h>
+#include <unistd.h>
 
 namespace PREW {
 namespace CppUtils {
@@ -13,6 +17,42 @@ bool Sys::path_exists (const std::string& path) {
   **/
   struct stat buffer;   
   return (stat (path.c_str(), &buffer) == 0); 
+}
+
+//------------------------------------------------------------------------------
+
+bool Sys::file_writable(const std::string& file_path) {
+  /** Check if framework is in principle able to write to given file path.
+      If file exists user must be able to write to it.
+      If file does not exist user must be able to write to directory.
+  **/
+  bool writable {};
+  if (file_path == "") { writable = false; }
+  else if (Sys::path_exists(file_path)) {
+    // File exists -> Check if it can be opened in append mode
+    try { 
+      std::ofstream file;
+      file.open( file_path.c_str(), std::ios::app ); // Open in append mode
+      file << ""; // Try appending empty string
+      file.close(); // Close file
+      writable = true;
+    } catch (const std::exception& /*e*/) { writable = false; }
+  } else {
+    // File doesn't exist -> Check if user has read & write access to directory
+    std::string dir_path = Str::get_dir_path_str(file_path);
+
+    // If file in current dir (either "." or no dir path) make dir path usable
+    if ( (dir_path == ".") || (dir_path == "") ) { dir_path = "./."; }
+    
+    // Check access writes to directory
+    if ( access(Str::get_dir_path_str(dir_path).c_str(), R_OK | W_OK) == 0 ) {
+     writable = true;  
+   } else {
+     writable = false;  
+   }
+  }
+  
+  return writable;
 }
 
 //------------------------------------------------------------------------------

--- a/source/prew/src/CppUtils/Sys.cpp
+++ b/source/prew/src/CppUtils/Sys.cpp
@@ -8,12 +8,11 @@ namespace CppUtils {
 
 //------------------------------------------------------------------------------
 
-
-bool Sys::file_exists (const std::string& file_path) {
-  /** Quick check that file given by file path exists.
+bool Sys::path_exists (const std::string& path) {
+  /** Quick check that path is accessible (may be file or directory).
   **/
   struct stat buffer;   
-  return (stat (file_path.c_str(), &buffer) == 0); 
+  return (stat (path.c_str(), &buffer) == 0); 
 }
 
 //------------------------------------------------------------------------------

--- a/source/prew/src/Input/DataReader.cpp
+++ b/source/prew/src/Input/DataReader.cpp
@@ -13,7 +13,7 @@ namespace Input {
 DataReader::DataReader(InputInfo *input_info) :
   m_input_info(input_info)
 {
-  if ( ! CppUtils::Sys::file_exists(input_info->m_file_path) ) {
+  if ( ! CppUtils::Sys::path_exists(input_info->m_file_path) ) {
     throw std::invalid_argument(("File not found: " + input_info->m_file_path).c_str());
   }
 }

--- a/source/prew/src/Output/Printer.cpp
+++ b/source/prew/src/Output/Printer.cpp
@@ -1,0 +1,255 @@
+#include <CppUtils/Str.h>
+#include <CppUtils/Sys.h>
+#include <Output/Printer.h>
+
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+
+namespace PREW {
+namespace Output {
+  
+//------------------------------------------------------------------------------
+// Constructors
+
+Printer::Printer( std::string file_path ) : m_file_path(file_path) {
+  /** Constructor assesses if file is accessible.
+  **/
+  if (! CppUtils::Sys::file_writable(file_path)) {
+    throw std::invalid_argument("No write access to " + m_file_path);
+  }
+}
+
+//------------------------------------------------------------------------------
+// Writing functions
+
+void Printer::new_setup(
+  int energy,
+  const Connect::DataConnector & connector
+) {
+  /** Start a new setup defined by the function links in the data connector and 
+      the energy at which the fit is performed.
+      Output of any previous setup(s) is saved.
+  **/
+  this->save_setup_output();
+  this->reset_setup();
+  this->add_meta_info(energy,connector);
+}
+
+void Printer::add_fit( const Fit::FitResult & result ) {
+  /** Add the content of a FitResult object to the current setup output.
+  **/
+  if (m_n_fits == 0) { this->add_par_info(result); } // Collect general par info
+  this->add_fit_res(result);
+  m_n_fits++;
+}
+
+void Printer::write(const std::string & mode) const {
+  /** Write the current output of all setups into the file at the location
+      defined in the constructor.
+      The mode determines how file is accessed. Options are:
+        "overwrite" -> Overwrites previous file content
+        "append"    -> Appends at end of file to previous content
+  **/
+  
+  // Determine file opening/writing mode
+  std::ios::openmode open_mode;
+  if ( mode == "overwrite" )    { open_mode = std::ios::trunc; }
+  else if ( mode == "append ")  { open_mode = std::ios::app; }
+  else { throw std::invalid_argument("Unknown opening mode: " + mode); }
+  
+  // Access file and write
+  std::ofstream outfile;
+  outfile.open( m_file_path.c_str(), open_mode ); // Open file
+  outfile << this->get_current_output(); // Write content
+  outfile.close(); // Close file
+}
+
+//------------------------------------------------------------------------------
+// Functions to check current status
+
+std::string Printer::get_current_output() const {
+  /** Return the current output of all added setups as it would be written into
+      the output file.
+  **/
+  return m_compl_setups + this->assemble_setup_output();
+}
+
+//------------------------------------------------------------------------------
+// Internal functions defining actual output
+
+void Printer::add_meta_info(
+  int energy, 
+  const Connect::DataConnector & connector
+) {
+  /** Add information about:
+        - energy
+        - polarisation configurations
+        - applied functions and their parameter names
+      as they were used in the given setup (defined by energy and connector).
+  **/
+  // Read energy
+  m_info_str += "Energy: " + std::to_string(energy) + "\n";
+  
+  // Read polarisation configurations
+  m_info_str += "Polarisation configurations: ";
+  m_info_str += "  [Name] ePol-Name pPol-Name ePol-Sign pPol-Sign\n";
+  for ( const auto & pol_link : connector.get_pol_links() ) {
+    if (pol_link.get_energy() == energy) {
+      m_info_str += "  [" + pol_link.get_pol_config() + "] " +
+                    pol_link.get_eM_pol() + " " +
+                    pol_link.get_eP_pol() + " " +
+                    std::to_string(pol_link.get_eM_sgn_factor()) + " " +
+                    std::to_string(pol_link.get_eP_sgn_factor()) + "\n";
+    }
+  }
+  
+  // Read the function links applied to the distributions
+  m_info_str += "Applied functions:\n";
+  m_info_str += "  [Distr-Name] [Pol-Config]\n";
+  m_info_str += "    Sig/Bkg Fct-Name {Par1,Par2,...} {C1,C2,...}\n";
+  for ( const auto & pred_link : connector.get_pred_links() ) {
+    if (pred_link.m_info.m_energy == energy) {
+      
+      // Read function links for signal predictions
+      m_info_str += "  [" + pred_link.m_info.m_distr_name + "] " +
+                    "[" + pred_link.m_info.m_pol_config + "]\n";
+                    
+      for ( const auto & fct_link: pred_link.m_fcts_links_sig ) {
+        m_info_str += "    Sig " +
+                      fct_link.m_fct_name + " {";
+        for (size_t p=0; p<fct_link.m_pars.size(); p++) {
+          if (p>0) { m_info_str += ","; }
+          m_info_str += fct_link.m_pars[p];
+        }
+        m_info_str += "} {";
+        for (size_t c=0; c<fct_link.m_coefs.size(); c++) {
+          if (c>0) { m_info_str += ","; }
+          m_info_str += fct_link.m_coefs[c];
+        }
+        m_info_str += "}\n";
+      }
+      
+      // Read function links for background predictions              
+      for ( const auto & fct_link: pred_link.m_fcts_links_bkg ) {
+        m_info_str += "    Bkg " +
+                      fct_link.m_fct_name + " {";
+        for (size_t p=0; p<fct_link.m_pars.size(); p++) {
+          if (p>0) { m_info_str += ","; }
+          m_info_str += fct_link.m_pars[p];
+        }
+        m_info_str += "} {";
+        for (size_t c=0; c<fct_link.m_coefs.size(); c++) {
+          if (c>0) { m_info_str += ","; }
+          m_info_str += fct_link.m_coefs[c];
+        }
+        m_info_str += "}\n";
+      }
+    }
+  }
+}
+
+void Printer::add_par_info( const Fit::FitResult & result ) {
+  /** Add information about the parameter names in this setup.
+  **/
+  m_res_str += "Parameters:";
+  for ( const auto & par_name: result.m_par_names ) {
+    m_res_str += " " + par_name;
+  }
+  m_res_str += "\n";
+}
+
+void Printer::add_fit_res( const Fit::FitResult & result ) {
+  /** Add information about results of one performed fit. Contains
+        - Final parameter values and uncertainties
+        - Final covariance and correlation matrices
+        - Chi-Squared at the minimum
+        - Expected distance from minimum
+        - Status of the covariance matrix caluclation (see Minuit2)
+  **/
+  m_res_str += "[F" + std::to_string(m_n_fits) + "]\n"; // fit result identifier
+  
+  // Parameter values and uncertainties
+  std::string vals_fin = "  Fin:";
+  std::string uncs_fin = "  Unc:";
+  for (size_t par=0;par<result.m_par_names.size();par++) {
+    vals_fin += " " + CppUtils::Str::sci_string(result.m_pars_fin.at(par));
+    uncs_fin += " " + CppUtils::Str::sci_string(result.m_uncs_fin.at(par));
+  }
+  m_res_str += vals_fin + "\n";
+  m_res_str += uncs_fin + "\n";
+  
+  // Covariance matrix
+  m_res_str += "Cov:\n";
+  for (size_t par1=0;par1<result.m_cov_matrix.size();par1++) {
+    m_res_str += " ";
+    for (size_t par2=0;par2<result.m_cov_matrix[par1].size();par2++) {
+      m_res_str += 
+        " " + CppUtils::Str::sci_string(result.m_cov_matrix[par1][par2]);
+    }
+    m_res_str += "\n";
+  }
+  
+  // Correlation matrix
+  m_res_str += "Cor:\n";
+  for (size_t par1=0;par1<result.m_cor_matrix.size();par1++) {
+    m_res_str += " ";
+    for (size_t par2=0;par2<result.m_cor_matrix[par1].size();par2++) {
+      m_res_str += " " + CppUtils::Str::sci_string(result.m_cor_matrix[par1][par2]);
+    }
+    m_res_str += "\n";
+  }
+  
+  // Fit quality measures
+  m_res_str += "Chi-Sq: " + CppUtils::Str::sci_string(result.m_chisq_fin) + "\n";
+  m_res_str += "EDM: " + CppUtils::Str::sci_string(result.m_edm_fin) + "\n";
+  m_res_str += "Cov.-Status: " + std::to_string(result.m_cov_status) + "\n";
+  
+  // Identifier that end of fit result is reached
+  m_res_str += "[END F" + std::to_string(m_n_fits) + "]\n";
+}
+
+std::string Printer::assemble_setup_output() const {
+  /** Assemble the complete output for the current setup (if one exists).
+      Includes fit meta information and information about all added fit results.
+  **/
+  std::string output = "";
+  if (this->has_setup_to_save()) {
+    output += std::string("") +
+      "<=========================== BEGIN ==========================>\n" +
+      "<SETUP>\n" + m_info_str + "<END SETUP>\n\n" +
+      "<FITS>\n" + m_res_str + "<END FITS>\n" +
+      "<============================ END ===========================>\n";
+  }
+  return output;
+}
+
+//------------------------------------------------------------------------------
+// Internal functions to handle output
+
+bool Printer::has_setup_to_save() const {
+  /** Check if there currently is a setup to save.
+  **/
+  return (m_info_str != "") || (m_res_str != "");
+}
+
+void Printer::save_setup_output() {
+  /** Internally save the complete output of the current setup into the string
+      that hold the total output of all setups.
+  **/
+  m_compl_setups += this->assemble_setup_output();
+}
+
+void Printer::reset_setup() {
+  /** Reset the strings and member variables describing the current setup.
+      Does not touch the total setup collection string.
+  **/
+  m_info_str = "";
+  m_res_str = "";
+  m_n_fits = 0;
+}
+
+//------------------------------------------------------------------------------
+
+}
+}

--- a/source/prew/src/Output/Printer.cpp
+++ b/source/prew/src/Output/Printer.cpp
@@ -44,6 +44,15 @@ void Printer::add_fit( const Fit::FitResult & result ) {
   m_n_fits++;
 }
 
+void Printer::add_fits( const Fit::ResultVec & results ) {
+  /** Add the content of all given FitResult objects to the current setup 
+      output.
+  **/
+  for ( const auto & result: results ) {
+    this->add_fit(result);
+  }
+}
+
 void Printer::write(const std::string & mode) const {
   /** Write the current output of all setups into the file at the location
       defined in the constructor.

--- a/source/prout/PrOut.py
+++ b/source/prout/PrOut.py
@@ -1,0 +1,219 @@
+""" Python module providing classes for reading PrEW output.
+"""
+
+#-------------------------------------------------------------------------------
+
+import numpy as np
+  
+#-------------------------------------------------------------------------------
+#=== Storage classes ===========================================================
+# Storage classes that can be used by user to further analyse fit results
+#-------------------------------------------------------------------------------
+  
+class FitResult:
+  """ Storage class for results of an individual fit.
+  """
+  pars_fin   = np.array([]) # Final parameter values after fit
+  uncs_fin   = np.array([]) # Final parameter uncertainties after fit
+  cov_matrix = np.array([[]]) # Covariance matrix after fit
+  cor_matrix = np.array([[]]) # Correlation matrix after fit
+  chisq_fin  = -1 # Chi-Squared at fit result
+  edm_fin    = 0  # Expected distance from minimum at fit result
+  cov_status = -1 # Status of covariance matrix calculation (see Minuit2)
+  
+#-------------------------------------------------------------------------------
+  
+class RunResult:
+  """ Storage class for results of a whole run of potentially multiple fits.
+  """
+  par_names = []  # Names of parameters used in fit
+  fit_results = []  # Results of individual fits performed in this setup
+
+#-------------------------------------------------------------------------------
+#===============================================================================
+#-------------------------------------------------------------------------------
+
+class Markers:
+  """ Define markers in a standard PrEW output file.
+  """
+  run_sep_beg = "<=========================== BEGIN ==========================>"
+  run_sep_end = "<============================ END ===========================>"
+  setup_beg = "<SETUP>"
+  setup_end = "<END SETUP>"
+  fits_beg = "<FITS>"
+  fits_end = "<END FITS>"
+  fit_id_beg = "[F"
+  fit_id_end = "[END F"
+  fit_id_cls = "]"
+  
+  def is_fit_id_beg(self,str):
+    """ Check if string fits shape of fit beginning identifier. """
+    return str.startswith(self.fit_id_beg) and str.endswith(self.fit_id_cls)
+  
+  def is_fit_id_end(self,str):
+    """ Check if string fits shape of fit end identifier. """
+    return str.startswith(self.fit_id_end) and str.endswith(self.fit_id_cls)
+    
+#-------------------------------------------------------------------------------
+
+class RunReader:
+  """ Class to read one PrEW run (which can contain many fits in the same 
+      setup).
+  """
+  run_result = RunResult() # The final result
+  markers = Markers() # The output markers which are used by PrEW
+  
+  def __init__(self,run_lines):
+    """ Class takes array of string lines representing the output of one PrEW 
+        run.
+    """
+    self.run_lines = run_lines
+        
+  def find_fits(self):
+    """ Find the string lines of the run which represent the individual fit 
+        results. 
+    """
+    fits = []
+    found_fits = False
+    for line in self.run_lines:
+      if line == self.markers.fits_beg:
+        # Found the beginning marker, start taking lines from here
+        found_fits = True
+        continue
+      elif line == self.markers.fits_end:
+        # Found the ending marker, stop taking lines
+        break
+      elif found_fits == True:
+        # If beginning marker already found use this line
+        fits.append(line)
+    return fits
+    
+  def add_fit_result(self,fit_result_lines):
+    """ Interpret the lines that describe one individual fit result and store 
+        the corresponding values.
+    """
+    fit_result = FitResult() # Class object decribing the resulting values
+    
+    for l in range(len(fit_result_lines)):
+      split_line = fit_result_lines[l].split(" ")
+      if len(split_line) == 0 : continue # Ignore empty lines
+      
+      if (split_line[0] == "Fin:"):
+        # Found final parameter values after fit
+        fit_result.pars_fin = np.array([float(val) for val in split_line[1:]])
+      elif (split_line[0] == "Unc:"):
+        # Found final uncertainties after fit
+        fit_result.uncs_fin = np.array([float(val) for val in split_line[1:]])
+      elif (split_line[0] == "Cov:"):
+        # Found covariance matrix after fit
+        cov_matrix = []
+        # Read the nxn (n=#parameters) matrix describing the covariance matrix
+        for p in range(len(self.run_result.par_names)):
+          cov_line = fit_result_lines[l+p+1].split(" ")
+          matrix_line = np.array([float(val) for val in cov_line])
+          if len(cov_matrix) == 0: cov_matrix = matrix_line
+          else: cov_matrix = np.vstack((cov_matrix,matrix_line))
+        fit_result.cov_matrix = cov_matrix
+      elif (split_line[0] == "Cor:"):
+        # Found correlation matrix after fit
+        cor_matrix = []
+        # Read the nxn (n=#parameters) matrix describing the correlation matrix
+        for p in range(len(self.run_result.par_names)):
+          cor_line = fit_result_lines[l+p+1].split(" ")
+          matrix_line = np.array([float(val) for val in cor_line])
+          if len(cor_matrix) == 0: cor_matrix = matrix_line
+          else: cor_matrix = np.vstack((cor_matrix,matrix_line))
+        fit_result.cor_matrix = cor_matrix
+      elif (split_line[0] == "Chi-Sq:"):
+        # Found the line describing the final chi^2 value
+        fit_result.chisq_fin = float(split_line[1])
+      elif (split_line[0] == "EDM:"):
+        # Found the line describing the final expected distance to the minimum
+        fit_result.edm_fin = float(split_line[1])
+      elif (split_line[0] == "Cov.-Status:"):
+        # Found the line with the status of the Minuit2 cov. matrix calculation
+        fit_result.cov_status = int(split_line[1])
+      
+    # Add the result of this individual fit to the result of the complete run
+    self.run_result.fit_results.append(fit_result)
+    
+  def read_fits(self,fits):
+    """ Read and interpret the lines describing the results of the individual 
+        fits.
+    """
+    current_fit_result = []
+    for line in fits:
+      split_line = line.split(" ")
+      if (len(split_line) > 0) and (split_line[0] == "Parameters:"):
+        # Found the line that has the parameter names
+        self.run_result.par_names = [par for par in split_line[1:]]
+      elif self.markers.is_fit_id_beg(line):
+        # Found the beginning of one individual fit result
+        current_fit_result = []
+      elif self.markers.is_fit_id_end(line):
+        # Found the end of this individual result -> Interpret it
+        self.add_fit_result(current_fit_result)
+      else:
+        # Line belongs to the current fit result
+        current_fit_result.append(line)
+      
+  def interpret(self):
+    """ Interpret the lines provided in the constructor and return the 
+        corresponding fit result class object.
+    """
+    self.read_fits(self.find_fits())
+    return self.run_result
+
+#-------------------------------------------------------------------------------
+
+class Reader:
+  """ Interface class to read a PrEW output file.
+      Call simply using 
+        reader = Reader(file_path)
+        reader.read()
+        results = reader.run_results
+      Return array of RunResult objects which contain the information which was 
+      output by PrEW.
+  """
+  markers = Markers() # Line markers used by PrEW
+  lines = [] # Line from input file
+  run_results = [] # Results after reading the file
+  
+  def __init__(self,file_path):
+    """ Constructor take the PrEW output file path
+    """
+    self.file_path = file_path
+    
+  def identify_runs(self):
+    """ Look through the lines and identify individual PrEW runs.
+        Such runs are fully independent but can be stored in the same file.
+    """
+    runs = []
+    current_run = []
+    found_run = False
+    for line in self.lines:
+      line = line.strip() # Remove trailing/leading whitespaces etc.
+      if line == self.markers.run_sep_beg:
+        # Found beginning of run -> Start reading lines
+        found_run = True
+      elif (line == self.markers.run_sep_end) and (current_run != []):
+        # Found end of one run, don't read lines unless new one found
+        runs.append(current_run)
+        found_run = False
+      elif found_run:
+        # Append line to current run
+        current_run.append(line)
+    return runs
+
+  def read(self):
+    """ Read and interpret the line of the input file.
+    """
+    with open(self.file_path) as f:
+      self.lines = f.readlines() # list containing lines of file
+
+    runs = self.identify_runs()
+    for run in runs:
+      run_reader = RunReader(run)
+      self.run_results.append(run_reader.interpret())
+
+#-------------------------------------------------------------------------------

--- a/source/tests/CppUtils/test_Str.cpp
+++ b/source/tests/CppUtils/test_Str.cpp
@@ -1,0 +1,26 @@
+#include <CppUtils/Str.h>
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+using namespace PREW::CppUtils;
+
+//------------------------------------------------------------------------------
+// Tests string helper functions
+
+TEST(TestStr, StringSplitting) {
+  // Test splitting of string into vector using a delimiter
+  
+  std::string str = "12 ab,c 3de, 45 fg";
+  
+  auto space_split = Str::string_to_vec(str, " ");
+  auto comma_split = Str::string_to_vec(str, ",");
+  
+  ASSERT_EQ(space_split.size(), 5);
+  ASSERT_EQ(comma_split.size(), 3);
+  ASSERT_STREQ(space_split[0].c_str(), "12");
+  ASSERT_STREQ(comma_split[0].c_str(), "12 ab");
+}
+
+//------------------------------------------------------------------------------

--- a/source/tests/CppUtils/test_Str.cpp
+++ b/source/tests/CppUtils/test_Str.cpp
@@ -42,8 +42,12 @@ TEST(TestStr, ScientificNotationString) {
 
 TEST(TestStr, DirectoryFromPath) {
   // Test getting the directory path string from a full file path string
-  std::string file_path = "~/home/test/blabla/get.out";
-  ASSERT_STREQ(Str::get_dir_path_str(file_path).c_str(), "~/home/test/blabla");
+  std::string f1_path = "~/home/test/blabla/get.out";
+  std::string f2_path = "get.out";
+  std::string f3_path = "~/home/test/blabla/";
+  ASSERT_STREQ(Str::get_dir_path_str(f1_path).c_str(), "~/home/test/blabla");
+  ASSERT_STREQ(Str::get_dir_path_str(f2_path).c_str(), "");
+  ASSERT_STREQ(Str::get_dir_path_str(f3_path).c_str(), "~/home/test/blabla");
 }
 
 //------------------------------------------------------------------------------

--- a/source/tests/CppUtils/test_Str.cpp
+++ b/source/tests/CppUtils/test_Str.cpp
@@ -40,5 +40,10 @@ TEST(TestStr, ScientificNotationString) {
   ASSERT_STREQ(Str::sci_string(i,5).c_str(), "-987654321");
 }
 
+TEST(TestStr, DirectoryFromPath) {
+  // Test getting the directory path string from a full file path string
+  std::string file_path = "~/home/test/blabla/get.out";
+  ASSERT_STREQ(Str::get_dir_path_str(file_path).c_str(), "~/home/test/blabla");
+}
 
 //------------------------------------------------------------------------------

--- a/source/tests/CppUtils/test_Str.cpp
+++ b/source/tests/CppUtils/test_Str.cpp
@@ -23,4 +23,22 @@ TEST(TestStr, StringSplitting) {
   ASSERT_STREQ(comma_split[0].c_str(), "12 ab");
 }
 
+TEST(TestStr, ScientificNotationString) {
+  // Test conversion of number to string in scientific notation
+  double d = 123456789.098765e8;
+  float  f = 0.00000006574839;
+  int    i = -987654321;
+
+  ASSERT_STREQ(Str::sci_string(d,2).c_str(), "1.23e+16");
+  ASSERT_STREQ(Str::sci_string(d,9).c_str(), "1.234567891e+16");
+  ASSERT_STREQ(Str::sci_string(d,15).c_str(), "1.234567890987650e+16");
+  ASSERT_STREQ(Str::sci_string(f,1).c_str(), "6.6e-08");
+  ASSERT_STREQ(Str::sci_string(f,3).c_str(), "6.575e-08");
+  ASSERT_STREQ(Str::sci_string(f,6).c_str(), "6.574839e-08");
+
+  // Special case: There is no scientific notation for integers in C++ 
+  ASSERT_STREQ(Str::sci_string(i,5).c_str(), "-987654321");
+}
+
+
 //------------------------------------------------------------------------------

--- a/source/tests/CppUtils/test_Sys.cpp
+++ b/source/tests/CppUtils/test_Sys.cpp
@@ -7,11 +7,15 @@ using namespace PREW::CppUtils;
 //------------------------------------------------------------------------------
 // Tests for system helpers
 
-TEST(TestSys, FileFinding) {
-  /** Test that existing files are found and non-existing not.
+TEST(TestSys, CheckPathExistance) {
+  /** Test that existing path (file or directory) is found and non-existing not.
   **/
-  ASSERT_EQ( Sys::file_exists("../testdata/RK_examplefile_500_250_2018_04_03.root"), true );
-  ASSERT_EQ( Sys::file_exists("./obviously_wrong_file_path.root"), false );
+  ASSERT_EQ( 
+    Sys::path_exists("../testdata/RK_examplefile_500_250_2018_04_03.root"), 
+    true 
+  );
+  ASSERT_EQ( Sys::path_exists("../testdata"), true );
+  ASSERT_EQ( Sys::path_exists("./obviously_wrong_path"), false );
 }
 
 //------------------------------------------------------------------------------

--- a/source/tests/CppUtils/test_Sys.cpp
+++ b/source/tests/CppUtils/test_Sys.cpp
@@ -18,4 +18,23 @@ TEST(TestSys, CheckPathExistance) {
   ASSERT_EQ( Sys::path_exists("./obviously_wrong_path"), false );
 }
 
+TEST(TestSys, CheckFileWritability) {
+  // Test checking if a file can written to
+  EXPECT_EQ(Sys::file_writable(""), false);
+  
+  // Should be able to write to current dir and other existing dir
+  EXPECT_EQ(Sys::file_writable("nonexistent_test_file.txt"), true);
+  EXPECT_EQ(Sys::file_writable("./nonexistent_test_file.txt"), true);
+  EXPECT_EQ(Sys::file_writable("../build/nonexistent_test_file.txt"), true);
+
+  // Should be able to write to random (existent) Makefile in build dir
+  EXPECT_EQ(Sys::file_writable("../build/Makefile"), true);
+  
+  // Should be able to write to file in root-level bin dir
+  EXPECT_EQ(Sys::file_writable("/usr/testfile.txt"), false);
+  
+  // Should not be able to write to non-existent directory 
+  EXPECT_EQ(Sys::file_writable("/gobblegobblgobble/test.txt"), false);
+}
+
 //------------------------------------------------------------------------------

--- a/source/tests/Fit/test_FitResult.cpp
+++ b/source/tests/Fit/test_FitResult.cpp
@@ -37,6 +37,6 @@ TEST(TestFitResult, StreamOperatorEmptyResult) {
   std::stringstream buffer;
   buffer << r;
   std::string output = buffer.str();
-  std::string expected = "Parameters:\n\nCovariance matrix:\n\nCorrelation matrix:\n\nFit quality measures:\nChi^2 = 0.000000\nEDM   = 0.000000\nCov. matrix status : 0";
+  std::string expected = "Parameters:\n\nCovariance matrix:\n\nCorrelation matrix:\n\nFit quality measures:\nChi^2 = 0.0000000e+00\nEDM   = 0.0000000e+00\nCov. matrix status : 0";
   ASSERT_STREQ(output.c_str(),expected.c_str());
 }

--- a/source/tests/Output/test_Printer.cpp
+++ b/source/tests/Output/test_Printer.cpp
@@ -1,0 +1,19 @@
+#include <Output/Printer.h>
+
+#include <gtest/gtest.h>
+
+using namespace PREW::Output;
+
+//------------------------------------------------------------------------------
+// Tests for the Printer output class
+
+TEST(TestPrinter, ExceptionOnInaccessibleFile) {
+  ASSERT_THROW(Printer(""), std::invalid_argument);
+}
+
+TEST(TestPrinter, TrivialConstructor) {
+  // Test trivial constructor on accessible file (but never write to file)
+  ASSERT_STREQ(Printer("../build/Makefile").get_current_output().c_str(), "");
+}
+
+//------------------------------------------------------------------------------


### PR DESCRIPTION
- Add missing test for string splitting helper function.
- Add string helper function to convert a number to a string in scientific notation with given precision.
- Add test for scientific notation string helper function.
- Add alias for vectors of FitResult objects.
- Use scientific notation in output of FitResult stream operator.
- Adjust FitResult stream operator test to scientific notation.
- Rename file checking function more accurately to path checking function.
- Adjust path checking function to also test directory existance check.
- Add helper function to get the directory path part of a file path string.
- Add test for directory part getter function.
- Fix bug caused because I forgot to rename the path check function in DataReader.
- Adjust helper function that extracts the directory path from a full file path to case where file path does not contain directory.
- Adjust test of dir path extraction function to test paths without dir or file.
- Add helper function that tests if a file could in principle be written to.
- Add test for helper function that tests if file is writable.
- Add Printer class that can print result and information about fits to a file a well-defined format.
- Add simple tests for Printer class (not many, would make it too complicated).
- Add a function to the output Printer class that allows adding a whole vector of fit results as output.
- Add sections on the idea and usage of PrEW to its Readme.
- Add a python module called PrOut that can be used to interpret the PrEW output files.
- Instruct gitignore to ignore python compilation directories.
- Add section in Readme on usage of PrOut.