### PR TITLE
Change definition of third asymmetry

### DIFF
--- a/source/prew/src/Fcts/Physics.cpp
+++ b/source/prew/src/Fcts/Physics.cpp
@@ -82,9 +82,9 @@ double Physics::asymm_2chixs_a1 (
     in the case that all four chiral cross sections are allowed.
     The four factors are chosen such that the sum of the chiral cross sections
     is not modified, while the asymmetries is modified be an addative constant.
-      A_I   =   (xs0 - xs1 + xs2 - xs3) / (xs0 + xs1 + xs2 + xs3)
-      A_II  =   (xs0 + xs1 - xs2 - xs3) / (xs0 + xs1 + xs2 + xs3)
-      A_III = (3*xs0 - xs1 - xs2 - xs3) / (xs0 + xs1 + xs2 + xs3)
+      A_I   = (xs0 - xs1 + xs2 - xs3) / (xs0 + xs1 + xs2 + xs3)
+      A_II  = (xs0 + xs1 - xs2 - xs3) / (xs0 + xs1 + xs2 + xs3)
+      A_III = (xs0 - xs1 - xs2 + xs3) / (xs0 + xs1 + xs2 + xs3)
       A_x -> A'_x = A_x + DeltaA_x
 **/
 
@@ -103,7 +103,8 @@ double Physics::asymm_4chixs_a0 (
                   p[1] - Change in asymmetry II DeltaA_II
                   p[2] - Change in asymmetry III DeltaA_III
   **/
-  return 1 + 0.25 * (c[0] + c[1] + c[2] + c[3]) / c[0] * (*(p[2]));
+  return 1 + 0.25 * (c[0] + c[1] + c[2] + c[3]) / c[0] 
+              * ( (*(p[0])) + (*(p[1])) + (*(p[2])) );
 }
                         
 double Physics::asymm_4chixs_a1 (
@@ -122,7 +123,7 @@ double Physics::asymm_4chixs_a1 (
                   p[2] - Change in asymmetry III DeltaA_III
   **/
   return 1 - 0.25 * (c[0] + c[1] + c[2] + c[3]) / c[1] 
-              * ( (*(p[2])) - 2 * (*(p[1])) );
+              * ( (*(p[0])) - (*(p[1])) + (*(p[2])) );
 }
 
 double Physics::asymm_4chixs_a2 (
@@ -140,8 +141,8 @@ double Physics::asymm_4chixs_a2 (
                   p[1] - Change in asymmetry II DeltaA_II
                   p[2] - Change in asymmetry III DeltaA_III
   **/
-  return 1 - 0.25 * (c[0] + c[1] + c[2] + c[3]) / c[2] 
-              * ( (*(p[2])) - 2 * (*(p[0])) );
+  return 1 + 0.25 * (c[0] + c[1] + c[2] + c[3]) / c[2] 
+              * ( (*(p[0])) - (*(p[1])) - (*(p[2])) );
 }
                         
 double Physics::asymm_4chixs_a3 (
@@ -160,7 +161,7 @@ double Physics::asymm_4chixs_a3 (
                   p[2] - Change in asymmetry III DeltaA_III
   **/
   return 1 - 0.25 * (c[0] + c[1] + c[2] + c[3]) / c[3] 
-              * ( 2 * (*(p[0])) + 2 * (*(p[1])) - (*(p[2])) );
+              * ( (*(p[0])) + (*(p[1])) - (*(p[2])) );
 }
 
 //------------------------------------------------------------------------------

--- a/source/tests/Fncts/test_Physics.cpp
+++ b/source/tests/Fncts/test_Physics.cpp
@@ -96,28 +96,27 @@ TEST(TestPhysics, AsymmetryFactors4Allowed) {
   
   // Test function against values I got from hand-calculator
   ASSERT_EQ(
-    Num::equal_to_eps(Physics::asymm_4chixs_a0({},c,p_ptrs), 1.021360921, 1e-9), 
+    Num::equal_to_eps(Physics::asymm_4chixs_a0({},c,p_ptrs), 1.039670281, 1e-9), 
     true 
-  ) << "Expected " << 1.021360921 
+  ) << "Expected " << 1.039670281 
   << " got " << Physics::asymm_4chixs_a0({},c,p_ptrs);
   
   ASSERT_EQ(
-    Num::equal_to_eps(Physics::asymm_4chixs_a1({},c,p_ptrs), 0.7796055619,1e-9), 
+    Num::equal_to_eps(Physics::asymm_4chixs_a1({},c,p_ptrs), 0.6914477866,1e-9), 
     true 
-  ) << "Expected " << 0.7796055619 
+  ) << "Expected " << 0.6914477866 
   << " got " << Physics::asymm_4chixs_a1({},c,p_ptrs);
   
   ASSERT_EQ(
-    Num::equal_to_eps(Physics::asymm_4chixs_a2({},c,p_ptrs), 69.88593567, 1e-7), 
+    Num::equal_to_eps(Physics::asymm_4chixs_a2({},c,p_ptrs), 38.0924269, 1e-9), 
     true 
-  ) << "Expected " << 69.88593567 
+  ) << "Expected " << 38.0924269 
   << " got " << Physics::asymm_4chixs_a2({},c,p_ptrs);
   
-  // Result is negative -> Does not make physical sense, but computational
   ASSERT_EQ(
-    Num::equal_to_eps(Physics::asymm_4chixs_a3({},c,p_ptrs), -0.2344891008, 1e-9), 
+    Num::equal_to_eps(Physics::asymm_4chixs_a3({},c,p_ptrs), 1.24689782, 1e-9), 
     true 
-  ) << "Expected " << -0.2344891008 
+  ) << "Expected " << 1.24689782 
   << " got " << Physics::asymm_4chixs_a3({},c,p_ptrs);
 }
 


### PR DESCRIPTION
- Change definition of third asymmetry (in case of three free chiral configurations) and accordingly change asymmetry factors.
- Adapt asymmetry factor function tests to new asymmetry definition.