### PR TITLE
Improve fit output

### DIFF
--- a/source/prew/include/Fit/FitResult.h
+++ b/source/prew/include/Fit/FitResult.h
@@ -14,9 +14,18 @@ namespace Fit {
     std::vector<std::vector<double>> m_cov_matrix {};
     std::vector<std::vector<double>> m_cor_matrix {};
     
+    // Fit setup information
+    int m_n_bins {};
+    int m_n_free_pars {};
+    
+    // Minimization process information
+    int m_n_fct_calls {}; // Number of function calls by minimizer
+    int m_n_iters {};     // Number of iterations in minimization stepping
+    
     // Fit quality measures
     double m_chisq_fin {};
     double m_edm_fin {}; // Expected distance from minimum
+    int m_min_status {}; // Can be 0-6 (0=success,1&2&5=cov-problems,3=edm-above-max,4=call-limit-reached,6=unexpected)
     int m_cov_status {};
     
     bool operator==(const FitResult& result) const;

--- a/source/prew/include/Fit/FitResult.tpp
+++ b/source/prew/include/Fit/FitResult.tpp
@@ -16,6 +16,12 @@ OStream& operator<<(OStream& os, const PREW::Fit::FitResult& fr) {
   using namespace PREW; // CppUtils::Str
   
   std::string output {};
+  
+  output.append("Fit setup info:\n");
+  output.append("#bins: " + std::to_string(fr.m_n_bins) + "\n");
+  output.append("#free pars: " + std::to_string(fr.m_n_free_pars) + "\n");
+  output.append("\n");
+  
   output.append("Parameters:\n");
   for (size_t par=0;par<fr.m_par_names.size();par++) {
     output.append(
@@ -65,9 +71,14 @@ OStream& operator<<(OStream& os, const PREW::Fit::FitResult& fr) {
   }
   output.append("\n");
 
+  output.append("Minimization information:\n");
+  output.append("#Fct.-calls = " + std::to_string(fr.m_n_fct_calls) + "\n");
+  output.append("#Iterations = " + std::to_string(fr.m_n_iters) + "\n");
+  
   output.append("Fit quality measures:\n");
   output.append("Chi^2 = " + CppUtils::Str::sci_string(fr.m_chisq_fin) + "\n");
   output.append("EDM   = " + CppUtils::Str::sci_string(fr.m_edm_fin) + "\n");
+  output.append("Minimizer status : " + std::to_string(fr.m_min_status) + "\n");
   output.append("Cov. matrix status : " + std::to_string(fr.m_cov_status));
   
   // Feed the output string into the given stream

--- a/source/prew/src/Fit/ChiSqMinimizer.cpp
+++ b/source/prew/src/Fit/ChiSqMinimizer.cpp
@@ -128,8 +128,16 @@ void ChiSqMinimizer::update_result() {
   m_result.m_pars_fin = std::vector<double>( m_minimizer->X(), m_minimizer->X()+n_pars );
   m_result.m_uncs_fin = std::vector<double>( m_minimizer->Errors(), m_minimizer->Errors()+n_pars );
   
+  m_result.m_n_bins = m_container->m_fit_bins.size();
+  m_result.m_n_free_pars = m_minimizer->NFree();
+  
+  // Minimization process information
+  m_result.m_n_fct_calls = m_minimizer->NCalls();
+  m_result.m_n_iters = m_minimizer->NIterations();
+  
   m_result.m_chisq_fin = m_minimizer->MinValue(); 
   m_result.m_edm_fin = m_minimizer->Edm();
+  m_result.m_min_status = m_minimizer->Status();
   m_result.m_cov_status = m_minimizer->CovMatrixStatus();
 }
 

--- a/source/prew/src/Fit/FitResult.cpp
+++ b/source/prew/src/Fit/FitResult.cpp
@@ -12,20 +12,28 @@ bool FitResult::operator==(const FitResult& result) const {
     ( this->m_par_names == result.m_par_names ) &&
     ( this->m_pars_fin == result.m_pars_fin ) &&
     ( this->m_uncs_fin == result.m_uncs_fin ) &&
+    ( this->m_n_bins == result.m_n_bins ) &&
+    ( this->m_n_free_pars == result.m_n_free_pars ) &&
+    ( this->m_n_fct_calls == result.m_n_fct_calls ) &&
+    ( this->m_n_iters == result.m_n_iters ) &&
     CppUtils::Num::equal_to_eps( this->m_chisq_fin, result.m_chisq_fin )  &&
     CppUtils::Num::equal_to_eps( this->m_edm_fin, result.m_edm_fin )  &&
+    ( this->m_min_status == result.m_min_status ) &&
     ( this->m_cov_status == result.m_cov_status ) &&
     ( this->m_cov_matrix.size() == result.m_cov_matrix.size() ) &&
     ( this->m_cor_matrix.size() == result.m_cor_matrix.size() );
-    
-  for (unsigned int i=0; i<this->m_cov_matrix.size(); i++) {
-    are_equal = are_equal && 
-      (this->m_cov_matrix[i] == result.m_cov_matrix[i]);
-  }
   
-  for (unsigned int i=0; i<this->m_cor_matrix.size(); i++) {
-    are_equal = are_equal && 
-      (this->m_cor_matrix[i] == result.m_cor_matrix[i]);
+  if (are_equal) {  
+    // Check if cov. and cor. matrix are fully equal
+    for (unsigned int i=0; i<this->m_cov_matrix.size(); i++) {
+      are_equal = are_equal && 
+        (this->m_cov_matrix[i] == result.m_cov_matrix[i]);
+    }
+    
+    for (unsigned int i=0; i<this->m_cor_matrix.size(); i++) {
+      are_equal = are_equal && 
+        (this->m_cor_matrix[i] == result.m_cor_matrix[i]);
+    }
   }
   
   return are_equal;

--- a/source/prew/src/Output/Printer.cpp
+++ b/source/prew/src/Output/Printer.cpp
@@ -209,9 +209,18 @@ void Printer::add_fit_res( const Fit::FitResult & result ) {
     m_res_str += "\n";
   }
   
+  //Fit setup info
+  m_res_str += "NBins: " + std::to_string(result.m_n_bins) + "\n";
+  m_res_str += "NFreePars: " + std::to_string(result.m_n_free_pars) + "\n";
+  
+  //Minimization information
+  m_res_str += "NFctCalls: " + std::to_string(result.m_n_fct_calls) + "\n";
+  m_res_str += "NIterations: " + std::to_string(result.m_n_iters) + "\n";
+  
   // Fit quality measures
   m_res_str += "Chi-Sq: " + CppUtils::Str::sci_string(result.m_chisq_fin) + "\n";
   m_res_str += "EDM: " + CppUtils::Str::sci_string(result.m_edm_fin) + "\n";
+  m_res_str += "Min.-Status: " + std::to_string(result.m_min_status) + "\n";
   m_res_str += "Cov.-Status: " + std::to_string(result.m_cov_status) + "\n";
   
   // Identifier that end of fit result is reached

--- a/source/prout/PrOut.py
+++ b/source/prout/PrOut.py
@@ -17,8 +17,13 @@ class FitResult:
   uncs_fin   = np.array([]) # Final parameter uncertainties after fit
   cov_matrix = np.array([[]]) # Covariance matrix after fit
   cor_matrix = np.array([[]]) # Correlation matrix after fit
+  n_bins = -1;      # Number of bins that the minimization was performed on
+  n_free_pars = -1; # Number of non-fixed parameters
+  n_fct_calls = -1; # Number of chi^2-function calls by minimizer
+  n_iters = -1;     # Number of iterations in minimization stepping
   chisq_fin  = -1 # Chi-Squared at fit result
   edm_fin    = 0  # Expected distance from minimum at fit result
+  min_status = -1 # Status of minimization (see Minuit2, 0=success)
   cov_status = -1 # Status of covariance matrix calculation (see Minuit2)
   
 #-------------------------------------------------------------------------------
@@ -124,12 +129,27 @@ class RunReader:
           if len(cor_matrix) == 0: cor_matrix = matrix_line
           else: cor_matrix = np.vstack((cor_matrix,matrix_line))
         fit_result.cor_matrix = cor_matrix
+      elif (split_line[0] == "NBins:"):
+        # Found line describing the number of input bins
+        fit_result.n_bins = int(split_line[1])
+      elif (split_line[0] == "NFreePars:"):
+        # Found line describing the number of free parameters
+        fit_result.n_free_pars = int(split_line[1])
+      elif (split_line[0] == "NFctCalls:"):
+        # Found line describing the number of function calls
+        fit_result.n_fct_calls = int(split_line[1])
+      elif (split_line[0] == "NIterations:"):
+        # Found line describing the number of iterations
+        fit_result.n_iters = int(split_line[1])
       elif (split_line[0] == "Chi-Sq:"):
         # Found the line describing the final chi^2 value
         fit_result.chisq_fin = float(split_line[1])
       elif (split_line[0] == "EDM:"):
         # Found the line describing the final expected distance to the minimum
         fit_result.edm_fin = float(split_line[1])
+      elif (split_line[0] == "Min.-Status:"):
+        # Found line describing minimzer status
+        fit_result.min_status = int(split_line[1])
       elif (split_line[0] == "Cov.-Status:"):
         # Found the line with the status of the Minuit2 cov. matrix calculation
         fit_result.cov_status = int(split_line[1])

--- a/source/tests/Fit/test_FitResult.cpp
+++ b/source/tests/Fit/test_FitResult.cpp
@@ -37,6 +37,6 @@ TEST(TestFitResult, StreamOperatorEmptyResult) {
   std::stringstream buffer;
   buffer << r;
   std::string output = buffer.str();
-  std::string expected = "Parameters:\n\nCovariance matrix:\n\nCorrelation matrix:\n\nFit quality measures:\nChi^2 = 0.0000000e+00\nEDM   = 0.0000000e+00\nCov. matrix status : 0";
+  std::string expected = "Fit setup info:\n#bins: 0\n#free pars: 0\n\nParameters:\n\nCovariance matrix:\n\nCorrelation matrix:\n\nMinimization information:\n#Fct.-calls = 0\n#Iterations = 0\nFit quality measures:\nChi^2 = 0.0000000e+00\nEDM   = 0.0000000e+00\nMinimizer status : 0\nCov. matrix status : 0";
   ASSERT_STREQ(output.c_str(),expected.c_str());
 }


### PR DESCRIPTION
- Add more parameters to fit result which describe how the minimization process went.
- Add new parameters to FitResult outstream.
- Adjust FitResult outstream test to new parameters.
- Adjust FitResult equal operator to new parameters.
- Write new parameters to FitResult in ChiSqMinimizer.
- Make printer print out the new FitResult parameters for each fit.
- Add new FitResult parameters to PrOut class and make PrOut classes read them.