### PR TITLE
Improve compile instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-/external/*
+/external
+/bin
 /build
+/include
+/lib
 *.root
 /source/prout/__pycache__

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ add_subdirectory(source/tests)
 add_subdirectory(external/googletest)
 
 # Install in local folder instead of system
-set(CMAKE_INSTALL_PREFIX ${PROJECT_BINARY_DIR}/bin)
+set(CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR})
 
 # Package name and version
 set(CPACK_PACKAGE_NAME "PrEW")

--- a/macros/compile.sh
+++ b/macros/compile.sh
@@ -91,7 +91,7 @@ make install # >> make.output  2>&1
 wait
 echo 
 echo "begin to test"
-./bin/PrEW_tst
+../bin/PrEW_test
 echo 
 echo "done!"
 # -------------------------------------------------#

--- a/source/prew/CMakeLists.txt
+++ b/source/prew/CMakeLists.txt
@@ -15,33 +15,26 @@ set(SOURCES ${SOURCES})
 ## target definitions #########################################################
 ###############################################################################
 
-add_executable(${BINARY}_run ${SOURCES})
+add_library(${BINARY} ${SOURCES})
 
 # just for example add some compiler flags
-target_compile_options(${BINARY}_run PUBLIC -std=c++1y 
-                       # Compiler warning/error flags
-                       -Wall -Wfloat-conversion -Wextra -Wunreachable-code -Wuninitialized 
-                       -pedantic-errors -Wold-style-cast -Wno-error=unused-variable
-                       -Wfloat-equal
-                       # Compiler optimisation
-                       -O3
-                     )
+target_compile_options(
+  ${BINARY} PUBLIC -std=c++1y 
+  # Compiler warning/error flags
+  -Wall -Wfloat-conversion -Wextra -Wunreachable-code -Wuninitialized 
+  -pedantic-errors -Wold-style-cast -Wno-error=unused-variable
+  -Wfloat-equal
+  # Compiler optimisation
+  -O3
+)
 
 ###############################################################################
 ## dependencies ###############################################################
 ###############################################################################
 
-# # this defines the variables Boost_LIBRARIES that contain all library names
-# # that we need to link to
-# find_package(Boost 1.36.0 COMPONENTS filesystem system REQUIRED)
-# 
-# target_link_libraries(example PUBLIC
-#   ${Boost_LIBRARIES}
-#   gtest_main
-#   # here you can add any library dependencies
-# )
-
-target_link_libraries(${BINARY}_run PUBLIC 
+# Link the needed libraries so that its compiled code can be used
+target_link_libraries(
+  ${BINARY} PUBLIC 
   ${SPDLOG_LIB} # Logging
   ROOT::Minuit2 # Minimization
 )
@@ -50,8 +43,9 @@ target_link_libraries(${BINARY}_run PUBLIC
 ## packaging ##################################################################
 ###############################################################################
 
-
-add_library(${BINARY}_lib STATIC ${SOURCES})
-
 # install binary in bin folder
-install(TARGETS ${BINARY}_run RUNTIME DESTINATION ${PROJECT_BINARY_DIR}/bin)
+install(
+  TARGETS ${BINARY} 
+  ARCHIVE DESTINATION lib
+  COMPONENT library
+)

--- a/source/prew/CMakeLists.txt
+++ b/source/prew/CMakeLists.txt
@@ -22,7 +22,10 @@ target_compile_options(${BINARY}_run PUBLIC -std=c++1y
                        # Compiler warning/error flags
                        -Wall -Wfloat-conversion -Wextra -Wunreachable-code -Wuninitialized 
                        -pedantic-errors -Wold-style-cast -Wno-error=unused-variable
-                       -Wfloat-equal)
+                       -Wfloat-equal
+                       # Compiler optimisation
+                       -O3
+                     )
 
 ###############################################################################
 ## dependencies ###############################################################

--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(BINARY ${CMAKE_PROJECT_NAME}_tst)
+set(BINARY ${CMAKE_PROJECT_NAME}_test)
 
 ###############################################################################
 ## file globbing ##############################################################
@@ -37,4 +37,4 @@ target_link_libraries(${BINARY} PUBLIC
 ## packaging ##################################################################
 ###############################################################################
 
-install(TARGETS ${BINARY} RUNTIME DESTINATION ${PROJECT_BINARY_DIR}/bin)
+install(TARGETS ${BINARY} RUNTIME DESTINATION bin)

--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -28,7 +28,7 @@ add_test(NAME ${BINARY} COMMAND ${BINARY})
 ###############################################################################
 
 target_link_libraries(${BINARY} PUBLIC 
-  ${CMAKE_PROJECT_NAME}_lib 
+  ${CMAKE_PROJECT_NAME} 
   gtest
   ROOT::Minuit2
 )


### PR DESCRIPTION
- Set the gcc optimization level to high (O3) for PrEW compilation to enable compiler optimization.
- Remove the instructions for a (nonsense) PrEW executable and build library only.
- Move PrEW installation to top level directory.
- Adapt compilation macro to new installation directories.
- Adapt gitignore file to ignore installation directories.