### PR TITLE
Make random number generators thread local

### DIFF
--- a/source/prew/include/CppUtils/Rnd.h
+++ b/source/prew/include/CppUtils/Rnd.h
@@ -11,8 +11,8 @@ namespace Rnd {
   **/
   
   // Global random number generator to avoid duplication of random numbers
-  static std::random_device rnd_device;
-  static std::mt19937 rnd_gen(rnd_device());
+  static thread_local std::random_device rnd_device;
+  static thread_local std::mt19937 rnd_gen(rnd_device());
   
   int poisson_fluctuate(double mean);
 }


### PR DESCRIPTION
- Make random number generators thread local to guarantee thread-safe generation of random numbers.