### PR TITLE
Optimize fitting core

### DIFF
--- a/source/prew/include/Fit/FitPar.h
+++ b/source/prew/include/Fit/FitPar.h
@@ -39,7 +39,7 @@ namespace Fit {
         bool is_fixed=false
       );
       
-      std::string get_name() const; // Get name
+      const std::string & get_name() const; // Get name
       double get_val_ini() const;   // Get initial value
       double get_unc_ini() const;   // Get initial value
       bool is_fixed() const;   // Get info if parameter is fixed

--- a/source/prew/src/Fit/ChiSqMinimizer.cpp
+++ b/source/prew/src/Fit/ChiSqMinimizer.cpp
@@ -18,6 +18,10 @@ ChiSqMinimizer::ChiSqMinimizer(FitContainer * container, const MinuitFactory &fa
 {
   this->update_chisq();
   m_minimizer = factory.create_minimizer();
+  
+  // Set minimizer strategy to high accuracy
+  // -> Want precision results, if that takes longer it takes longer.
+  m_minimizer->SetStrategy(2); 
 }
 
 //------------------------------------------------------------------------------

--- a/source/prew/src/Fit/ChiSqMinimizer.cpp
+++ b/source/prew/src/Fit/ChiSqMinimizer.cpp
@@ -34,10 +34,10 @@ void ChiSqMinimizer::update_chisq() {
       given by the fit container.
   **/
   m_chisq = 0.0;
-  for ( auto & bin : m_container->m_fit_bins ) {
+  for ( const auto & bin : m_container->m_fit_bins ) {
     m_chisq += std::pow( ( bin.get_val_mst() - bin.get_val_prd() ) /  bin.get_val_unc() , 2 );
   }
-  for ( auto & par : m_container->m_fit_pars ) {
+  for ( const auto & par : m_container->m_fit_pars ) {
     if (par.is_fixed()) { continue; } // Skip fixed parameters
     m_chisq += par.calc_constr_chisq();
   }
@@ -51,7 +51,7 @@ void ChiSqMinimizer::minimize() {
   // Create a vector holding the addresses of the parameter values
   // => Minimizer will directly change parameter values by changing the 
   //    values at the addresses
-  unsigned int n_pars = m_container->m_fit_pars.size();
+  const unsigned int n_pars = m_container->m_fit_pars.size();
   std::vector<double*> pars(n_pars);
   for ( unsigned int i=0; i<n_pars; i++ ){
     pars[i] = &(m_container->m_fit_pars[i].m_val_mod);

--- a/source/prew/src/Fit/FitPar.cpp
+++ b/source/prew/src/Fit/FitPar.cpp
@@ -20,7 +20,7 @@ FitPar::FitPar(
 //------------------------------------------------------------------------------
 // get functions
 
-std::string FitPar::get_name() const { return m_name; }
+const std::string & FitPar::get_name() const { return m_name; }
 double FitPar::get_val_ini() const { return m_val_ini; }
 double FitPar::get_unc_ini() const { return m_unc_ini; }
 bool FitPar::is_fixed() const { return m_is_fixed; }


### PR DESCRIPTION
- Make FitPar use constant reference returning.
- Use const correctness in ChiSqMinimizer for chi-squared calculation.
- Follow Minuit2 guideline to get most accurate possible result by setting the minimizer strategy always to 2 (which means high accuracy at the cost of more function calls).