### PR TITLE
Add poissonian log-likelihood minimizer

### DIFF
--- a/source/prew/include/CppUtils/Num.h
+++ b/source/prew/include/CppUtils/Num.h
@@ -6,6 +6,8 @@ namespace CppUtils {
 
 namespace Num {
   template<class T> bool equal_to_eps(const T & v1, const T & v2, const T eps=1e-9);
+  
+  double log_factorial (int x);
 }
 
 }

--- a/source/prew/include/Fit/PoissonNLLMinimizer.h
+++ b/source/prew/include/Fit/PoissonNLLMinimizer.h
@@ -1,0 +1,57 @@
+#ifndef LIB_POISSONNLLMINIMIZER_H
+#define LIB_POISSONNLLMINIMIZER_H 1
+
+#include <Fit/FitContainer.h>
+#include <Fit/MinuitFactory.h>
+#include <Fit/FitResult.h>
+
+#include <memory>
+
+#include "Minuit2/Minuit2Minimizer.h"
+
+namespace PrEW {
+namespace Fit {
+  
+  class PoissonNLLMinimizer {
+    /** Class that performs minimization of a negative Log-Likelihood (NLL)
+          - 2 * ln L({p}|{x})
+        in which the Likelihood L is poissonian.
+        For bins with an measurement above 25 a gaussian approximation is used.
+        Takes the fit parameters and the bins (whose prediction is connected
+        to the fit parameters).
+        The uncertainty of the measurement bins is not explicitely used 
+        because the Likelihood assumes a Poissonian fluctuation.
+    **/
+  
+    // Input
+    FitContainer * m_container {}; // Container with bins and parameters
+    std::unique_ptr<ROOT::Minuit2::Minuit2Minimizer> m_minimizer; // Minimizer created by factory
+    
+    // Output
+    double m_nll {}; // Current value of the negative log-likelihood
+    FitResult m_result {};
+    
+    // Internal functions
+    double nll_poisson(int n, double mu) const; // TODO Separate namespace
+    double nll_gaussian(double x, double mu, double sigma) const; // TODO Separate namespace
+    void update_nll();
+    
+    void collect_par_names();
+    void update_result();
+    
+    public:
+      // Constructors
+      PoissonNLLMinimizer(FitContainer * container, const MinuitFactory &factory);
+      
+      void minimize();
+      
+      // Get function
+      double get_nll() const;
+      const FitResult& get_result() const;
+  };
+  
+}
+}
+
+
+#endif

--- a/source/prew/src/CppUtils/Num.cpp
+++ b/source/prew/src/CppUtils/Num.cpp
@@ -1,0 +1,58 @@
+#include <CppUtils/Num.h>
+
+#include <stdexcept>
+
+namespace PrEW {
+namespace CppUtils {
+  
+//------------------------------------------------------------------------------
+
+double Num::log_factorial (int x) {
+  /** Explicit implementation of the natural logarithm of the factorial of an 
+      integer x:
+        ln x!
+      Uses the values the std::lgamma would give, but std::lgamma is not 
+      thread-safe.
+      Only defines the values up to 30 (for now).
+  **/
+  switch (x) {
+    case 0: return 0.000000;
+    case 1: return 0.000000;
+    case 2: return 0.693147;
+    case 3: return 1.791759;
+    case 4: return 3.178054;
+    case 5: return 4.787492;
+    case 6: return 6.579251;
+    case 7: return 8.525161;
+    case 8: return 10.604603;
+    case 9: return 12.801827;
+    case 10: return 15.104413;
+    case 11: return 17.502308;
+    case 12: return 19.987214;
+    case 13: return 22.552164;
+    case 14: return 25.191221;
+    case 15: return 27.899271;
+    case 16: return 30.671860;
+    case 17: return 33.505073;
+    case 18: return 36.395445;
+    case 19: return 39.339884;
+    case 20: return 42.335616;
+    case 21: return 45.380139;
+    case 22: return 48.471181;
+    case 23: return 51.606676;
+    case 24: return 54.784729;
+    case 25: return 58.003605;
+    case 26: return 61.261702;
+    case 27: return 64.557539;
+    case 28: return 67.889743;
+    case 29: return 71.257039;
+    case 30: return 74.658236;
+  }
+  throw std::out_of_range("Num::log_factorial only accepts integers 0-30.");
+  return -1; // Should never be reached
+}
+
+//------------------------------------------------------------------------------
+  
+} // Namespace CppUtils
+} // Namespace PrEW

--- a/source/prew/src/Fit/PoissonNLLMinimizer.cpp
+++ b/source/prew/src/Fit/PoissonNLLMinimizer.cpp
@@ -1,0 +1,267 @@
+#include <Fit/PoissonNLLMinimizer.h>
+#include <CppUtils/Num.h>
+
+#define _USE_MATH_DEFINES // To access mathematical constants such as pi
+#include <cmath>
+#include <limits> // For numerical limits (e.g. infinity)
+
+// External 
+#include "Math/Functor.h"
+#include "spdlog/spdlog.h"
+
+
+namespace PrEW {
+namespace Fit {
+
+//------------------------------------------------------------------------------
+// Constructors
+
+PoissonNLLMinimizer::PoissonNLLMinimizer(FitContainer * container, const MinuitFactory &factory) : 
+  m_container(container) 
+{
+  this->update_nll();
+  m_minimizer = factory.create_minimizer();
+}
+
+//------------------------------------------------------------------------------
+// get functions
+
+double PoissonNLLMinimizer::get_nll() const { return m_nll; }
+const FitResult& PoissonNLLMinimizer::get_result() const { return m_result; }
+
+//------------------------------------------------------------------------------
+// Log Likelihood functions => TODO: Different namespace
+
+double PoissonNLLMinimizer::nll_poisson(int n, double mu) const { 
+  /** Negative log likelihood (including factor -2) of poissonian probability.
+      n ... Number of measured events
+      mu ... expected value
+  **/
+  return - 2.0 * ( - CppUtils::Num::log_factorial(n) - mu + double(n) * std::log(mu) );
+}
+  
+double PoissonNLLMinimizer::nll_gaussian(double x, double mu, double sigma) const { 
+  /** Negative log likelihood (including factor -2) of gaussian probability.
+      x ... measured value
+      mu ... expected value
+      sigma ... uncertainty on x
+  **/
+  static const double log_2pi = std::log( 2.0 * M_PI );
+  return log_2pi + 2.0 * std::log( sigma ) + std::pow( (x - mu) / sigma , 2);
+}
+
+//------------------------------------------------------------------------------
+// Core functionality
+
+void PoissonNLLMinimizer::update_nll() {
+  /** Update the poissonian negative log-likelihood.
+      All measurement bins are assumed to have an positive integer value (>=0).
+  
+      Bins with a measurement below 25 use the poissonian log-likelihood:
+        NLL_bin = - 2.0 * ( - ln(n!) - mu + n * ln(mu) )
+        with the measured bin value n and it's prediction mu.
+        Since nothing keeps mu from being negative that case is treated:
+          for n == 0: NLL_bin (mu < 0) = 0
+          for n > 0:  NLL_bin (mu < 0) = inf
+        which continues the value NLL_bin would have at mu = 0.
+        
+      For bins with a measurement above 25 a gaussian approximation is used to 
+      avoid problems with logarithms of large numbers:
+        NLL_bin = ln( 2*pi * sigma^2) + (x - mu)^2 / sigma^2
+        where 
+          x = n ... measured bin value value
+          sigma = sqrt(mu) ... bin value uncertainty
+        
+      The gaussian NLL is also used for soft constraints on the parameters.
+      In that case:
+        x ... measured parameter value
+        mu ... current parameter value
+        sigma ... uncertainty on measured parameter value
+  **/
+  
+  m_nll = 0.0; // Reset NLL before summing it up again
+  
+  // Find log-likelihood contributions from bin values
+  for ( const auto & bin : m_container->m_fit_bins ) {
+    int n = int( bin.get_val_mst() ); // Measurements have to be integer
+    double mu = bin.get_val_prd();    // Prediction
+    
+    // Handle all possible cases of n and mu
+    if ( n == 0 ) {
+      if ( mu > 0 ) {
+        // Poisson NLL behaves well under these conditions
+        m_nll += this->nll_poisson(n, mu);
+      } else {
+        // Poisson NLL goes to zero for mu->0 for n==0, continue at 0 for
+        // mu < 0 as well.
+        // => Negative pred. not punished, assume will be fixed by other bins
+        m_nll += 0;
+      }
+    } else if ( n <= 25 ) {
+      if ( mu > 0 ) {
+        // Poisson NLL behaves well under these conditions
+        m_nll += this->nll_poisson(n, mu);
+      } else {
+        // Poisson NLL goes to infinity for mu->0 for n>0, continue at inf. for
+        // mu < 0 as well.
+        m_nll = std::numeric_limits<double>::infinity();
+        return; // No need to add any more
+      }
+    } else {
+      // Measured value big enough that a gaussian can be assumed
+      if ( mu > 0 ) {
+        // Gaussian well behaved
+        m_nll += this->nll_gaussian(double(n), mu, std::sqrt(mu));
+      } else {
+        // Gaussian assumption leads to infinity
+        m_nll = std::numeric_limits<double>::infinity();
+        return; // No need to add any more
+      }
+    }    
+    
+  } // End bin loop
+  
+  // Find log-likelihood contributions from parameter constraints
+  for ( const auto & par : m_container->m_fit_pars ) {
+    if ( (! par.is_fixed()) && par.has_constraint()) { 
+      // Parameter constraints are assumed to be gaussian
+      m_nll += 
+        this->nll_gaussian( 
+          par.m_val_mod, 
+          par.get_constr_val(), 
+          par.get_constr_unc()
+        );
+    }
+  }
+}
+
+void PoissonNLLMinimizer::minimize() {
+  /** Perform the actual negative log-likelihood minimization using Minuit2.
+      Will modify the m_val_mod of all parameters in the container!
+  **/
+  
+  // Set minimizer strategy to high accuracy
+  // -> Want precision results, if that takes longer it takes longer.
+  m_minimizer->SetStrategy(2); 
+  
+  // Tell minimizer to perform hessian error-calculation for accurate errors
+  m_minimizer->SetValidError(true); 
+  
+  // Create a vector holding the addresses of the parameter values
+  // => Minimizer will directly change parameter values by changing the 
+  //    values at the addresses
+  const unsigned int n_pars = m_container->m_fit_pars.size();
+  std::vector<double*> pars(n_pars);
+  for ( unsigned int i=0; i<n_pars; i++ ){
+    pars[i] = &(m_container->m_fit_pars[i].m_val_mod);
+  }
+    
+  // Thing that minimizer performs NLL minimization on
+  const ROOT::Math::Functor recalc_nll (
+    // Lambda function for the minimizer:
+    // Update the parameter set, then recalculate and return new NLL
+    [pars, n_pars, this](const double * _pars) { 
+      for ( unsigned int i=0; i<n_pars; i++ ) { *(pars[i]) = _pars[i]; }
+      this->update_nll();
+      return this->get_nll();
+    },
+    // Needs to know the correct number of parameters
+    n_pars
+  );
+  
+  // Set up minimizer by telling about function and parameters
+  m_minimizer->SetFunction(recalc_nll);
+  for ( unsigned int i_par=0; i_par<n_pars; i_par++ ){
+    FitPar par = m_container->m_fit_pars[i_par];
+    m_minimizer->SetVariable( i_par, par.get_name(), par.m_val_mod, par.get_unc_ini() );
+    // Check if parameter is fixed or limited
+    if (par.is_fixed()) {
+      m_minimizer->FixVariable(i_par); 
+    } else if (par.is_limited()) {
+      m_minimizer->SetVariableLimits( 
+        i_par, par.get_upper_lim(), par.get_lower_lim());
+    }
+  }
+  
+  // -------------------------------------------------------------------------//
+  // --------------------------------ACTION!----------------------------------//
+  // -------------------------------------------------------------------------//
+  m_minimizer->Minimize();
+  // -------------------------------------------------------------------------//
+  // -------------------------------------------------------------------------//
+  
+  // Check if any parameters were limited and if so reset parameters as free and 
+  // re-perform error calculation.
+  // This is recommended for Minuit to get more precise errors because without 
+  // limits no internal parameter transformations have to be performed.
+  bool was_limited = false;
+  for ( unsigned int i_par=0; i_par<n_pars; i_par++ ){
+    if ( m_container->m_fit_pars[i_par].is_limited() ) {
+      m_minimizer->SetVariable(
+        i_par, 
+        m_minimizer->VariableName(i_par), 
+        m_minimizer->X()[i_par],
+        m_minimizer->Errors()[i_par]
+      );
+      was_limited = true;
+    }
+  }
+  if ( was_limited ) { 
+    spdlog::debug("Minimisation used parameter limits, recalculating error without limits for accuracy.");
+    m_minimizer->Hesse(); 
+  }
+  
+  // Form a usable output collection
+  this->collect_par_names();
+  this->update_result();
+}
+
+//------------------------------------------------------------------------------
+// Result collecting
+
+void PoissonNLLMinimizer::collect_par_names() {
+  unsigned int n_pars = m_container->m_fit_pars.size();
+  m_result.m_par_names.resize(n_pars);
+  for ( unsigned int i_par=0; i_par<n_pars; i_par++ ){
+    m_result.m_par_names[i_par] = m_container->m_fit_pars[i_par].get_name();
+  }
+}
+
+void PoissonNLLMinimizer::update_result() {
+  /** Write the result of the minimization procedure into a output container.
+  **/
+  
+  if (m_result != FitResult()) {
+    spdlog::debug("FitResult not empty, will be overwritten.");
+  }
+  
+  unsigned int n_pars = m_container->m_fit_pars.size();
+  m_result.m_cov_matrix = std::vector<std::vector<double>>( n_pars, std::vector<double>(n_pars) );
+  m_result.m_cor_matrix = std::vector<std::vector<double>>( n_pars, std::vector<double>(n_pars) );
+  for ( unsigned int i_par=0; i_par<n_pars; i_par++ ){
+    for ( unsigned int j_par=0; j_par<n_pars; j_par++ ){
+      m_result.m_cov_matrix[i_par][j_par] = m_minimizer->CovMatrix(i_par, j_par);
+      m_result.m_cor_matrix[i_par][j_par] = m_minimizer->Correlation(i_par, j_par);
+    }
+  }
+  
+  m_result.m_pars_fin = std::vector<double>( m_minimizer->X(), m_minimizer->X()+n_pars );
+  m_result.m_uncs_fin = std::vector<double>( m_minimizer->Errors(), m_minimizer->Errors()+n_pars );
+  
+  m_result.m_n_bins = m_container->m_fit_bins.size();
+  m_result.m_n_free_pars = m_minimizer->NFree();
+  
+  // Minimization process information
+  m_result.m_n_fct_calls = m_minimizer->NCalls();
+  m_result.m_n_iters = m_minimizer->NIterations();
+  
+  m_result.m_chisq_fin = m_minimizer->MinValue(); 
+  m_result.m_edm_fin = m_minimizer->Edm();
+  m_result.m_min_status = m_minimizer->Status();
+  m_result.m_cov_status = m_minimizer->CovMatrixStatus();
+}
+
+//------------------------------------------------------------------------------
+
+}
+}

--- a/source/tests/CppUtils/test_Num.cpp
+++ b/source/tests/CppUtils/test_Num.cpp
@@ -1,14 +1,17 @@
 #include <gtest/gtest.h>
+
 #include <CppUtils/Num.h>
 
-// #include <random>
+#include <cmath>
+#include <numeric>
+#include <vector>
 
 using namespace PrEW::CppUtils;
 
 //------------------------------------------------------------------------------
 // Tests for equal_to_eps
 
-TEST(TestNum, OneEqOne) {
+TEST(TestNum, EqEpsOneEqOne) {
   // Test if one equals one at high precision
   std::vector<double> precisions
     {1e-1, 1e-2, 1e-3, 1e-5, 1e-7, 1e-9, 1e-11, 1e-13, 1e-15, 1e-18, 1e-20};
@@ -18,7 +21,7 @@ TEST(TestNum, OneEqOne) {
   }
 }
 
-TEST(TestNum, NanoPrecision) {
+TEST(TestNum, EqEpsNanoPrecision) {
   // Test if 10^-9 precision hold for different orders of magnitude
   srand(unsigned(1.0)); // Set random seed
   std::vector<double> test_numbers 
@@ -33,7 +36,7 @@ TEST(TestNum, NanoPrecision) {
   }
 }
 
-TEST(TestNum, UnequalWithOffsets) {
+TEST(TestNum, EqEpsUnequalWithOffsets) {
   // Test if numbers still recognized as unequal if large offsets are added
   double n1 = 2e-8;
   double n2 = 3e-8;
@@ -46,14 +49,46 @@ TEST(TestNum, UnequalWithOffsets) {
   }
 }
 
-TEST(TestNum, WorksForAllFloatingTypes) {
-  // Test that floating point comparison does not work for int
+TEST(TestNum, EqEpsWorksForAllFloatingTypes) {
+  // Test that floating point comparison works for all floating point types
   float f_val = 0.1;
   double d_val = 0.1;
   long double ld_val = 0.1;
   ASSERT_EQ(Num::equal_to_eps(f_val,f_val, (float)1e-9), true);
   ASSERT_EQ(Num::equal_to_eps(d_val,d_val, (double)1e-9), true);
   ASSERT_EQ(Num::equal_to_eps(ld_val,ld_val, (long double)1e-9), true);
+}
+
+//------------------------------------------------------------------------------
+
+TEST(TestNum, LogFactorialRangeException) {
+  // Test that log factorial function throws error when integer out of 
+  // available range
+  ASSERT_THROW(Num::log_factorial(-1), std::out_of_range);
+  ASSERT_THROW(Num::log_factorial(31), std::out_of_range);
+}
+
+TEST(TestNum, LogFactorialAccuracy) {
+  // Test the results of the custom log-factorial function against the cpp 
+  // standard lgamma function (which is not used because it isn't thread-safe)
+  int range_min = 0;
+  int range_max = 30;
+
+  // Create an integer array going from range_min to range_max
+  std::vector<int> range (range_max - range_min + 1);
+  std::iota(range.begin(),range.end(),range_min);
+  
+  // Test result of custom function against std::lgamma
+  for ( int i: range ) {
+    double custom_res = Num::log_factorial(i);
+    double std_res = std::lgamma(i+1); // Gamma function is (x-1)!
+    
+    // Special case lgamma(0) behaves wrong (gives inf, should give 0)
+    if ( i == 0 ) { std_res = 0; }
+    
+    EXPECT_EQ( Num::equal_to_eps( custom_res, std_res, 1e-6 ), true ) 
+      << "Custom function: " << custom_res << " , std::lgamma: " << std_res ;
+  }
 }
 
 //------------------------------------------------------------------------------

--- a/source/tests/Fit/test_PoissonNLLMinimizer.cpp
+++ b/source/tests/Fit/test_PoissonNLLMinimizer.cpp
@@ -1,0 +1,97 @@
+#include <gtest/gtest.h>
+
+#include <CppUtils/Num.h>
+#include <Fit/PoissonNLLMinimizer.h>
+
+#include <functional>
+#include <limits>
+#include <map>
+#include <vector>
+
+using namespace PrEW::CppUtils;
+using namespace PrEW::Fit;
+
+//------------------------------------------------------------------------------
+
+TEST(TestPoissonNLLMinimizer, TrivialConstructor) {
+  FitContainer container {};
+  MinuitFactory factory (ROOT::Minuit2::kMigrad, 100, 200, 0.05); // Simple Factory
+  PoissonNLLMinimizer pnll_minimizer (&container, factory);
+  ASSERT_EQ(pnll_minimizer.get_nll(), 0);
+  ASSERT_EQ(pnll_minimizer.get_result() == FitResult(), true);
+}
+
+//------------------------------------------------------------------------------
+
+TEST(TestPoissonNLLMinimizer, TestAllCases) {
+  // Test all six possible (n,mu) cases for a bin
+  int n_0 = 0;
+  int n_low = 3;
+  int n_high = 50;
+  
+  double pred_neg = -1;
+  double pred_low = 2;
+  double pred_high = 45;
+  
+  // Values for mu>0 for comparison calculated in python with scipy.stats
+  std::map<std::pair<int,double>,double> n_mu_res_vec = 
+  {
+    { {n_0, pred_neg},    0.0 },
+    { {n_0, pred_low},    4.0 },
+    { {n_low, pred_neg},  std::numeric_limits<double>::infinity() },
+    { {n_low, pred_low},  3.4246358550964384 },
+    { {n_high, pred_neg}, std::numeric_limits<double>::infinity() },
+    { {n_high, pred_high},6.20009511173522 }
+  };
+  
+  for (const auto & n_mu_res: n_mu_res_vec) {
+    int n = n_mu_res.first.first;
+    double mu = n_mu_res.first.second;
+    double res = n_mu_res.second;
+    
+    std::function<double()> prd = [mu]() { return mu; };
+    FitBin fb (n, 0, prd); // Measurement = 1 (uncertainty ignored)
+    FitContainer container {};
+    container.m_fit_bins = {fb};
+    MinuitFactory factory (ROOT::Minuit2::kMigrad, 100, 200, 0.05); // Simple Factory
+    PoissonNLLMinimizer pnll_minimizer (&container, factory);
+    
+    if ( std::isinf(res) ) {
+      EXPECT_EQ( std::isinf(pnll_minimizer.get_nll()), true ) 
+        << "Expected infinite result";
+    } else {
+      EXPECT_EQ(
+        Num::equal_to_eps( pnll_minimizer.get_nll(), res, 1e-6 ),
+        true
+      ) << "Got " << pnll_minimizer.get_nll() << " expected " << res;
+    }
+    
+  }
+}
+
+//------------------------------------------------------------------------------
+
+TEST(TestPoissonNLLMinimizer, ManyBinsConstructor) {
+  // Test with n FitBin's, range n from small to very large 
+  std::function<double()> trivial_prd = []() { return 0.5; }; // Prediction = 0
+  std::vector<int> n_bins = {20, 200, 2000, 20000, 200000};
+  MinuitFactory factory (ROOT::Minuit2::kMigrad, 100, 200, 0.05); // Simple Factory
+  
+  double one_bin_res = 2.386294361119891;
+  
+  for ( int n : n_bins ) {
+    FitContainer container {};
+    container.m_fit_bins = BinVec(n, FitBin(1.0, 1.0, trivial_prd));
+    PoissonNLLMinimizer pnll_minimizer (&container, factory);
+    EXPECT_EQ(
+      Num::equal_to_eps(pnll_minimizer.get_nll(), double(n)*one_bin_res, 1e-5),
+      true
+    ) << "Got " << pnll_minimizer.get_nll() 
+      << " expected " << double(n)*one_bin_res;
+  }
+}
+
+//------------------------------------------------------------------------------
+
+// TODO OTHER FUNCTIONALITIES EXACT SAME AS CHISQMINIMIZER
+// => HERE NO EXTRA TESTS -> TODO: UNIFY COMMON FUNCTIONALITIES


### PR DESCRIPTION
- Add a numerical helper function to safely get the log of the factorial of a number between 0 and 30.
- Add tests for the new log factorial helper function.
- Add a minimizer that is in structure same as ChiSqMinimizer but minimizes the Poissonian Log-Likelihood of the bins instead.
- Add tests for Poissonian Log-Likelihood minimizer.