### PR TITLE
Improve CoefDistr to allow global coefficients

### DIFF
--- a/source/prew/include/Data/CoefDistr.h
+++ b/source/prew/include/Data/CoefDistr.h
@@ -9,21 +9,38 @@
 namespace PrEW {
 namespace Data {
 
-  struct CoefDistr {
-    /** Class holding a coefficient for parameterised prediction of a 
-        distribution for one polarisation/chirality.
-    **/
-    
-    std::string m_coef_name {}; // Name that identifies this coefficient
-    DistrInfo m_info {}; // Info which identifies the corresponding distribution
-    
-    // Coefficient for each bin
-    std::vector<double> m_coefficients {};
-  };
+class CoefDistr {
+  /** Class holding a coefficient for parameterised prediction of a
+      distribution for one polarisation/chirality.
+      Coefficient can be local (different for different bins) or global
+      (same for all bins);
+  **/
+  std::string m_coef_name{}; // Name that identifies this coefficient
+  DistrInfo m_info{}; // Info which identifies the corresponding distribution
+
+  // Coefficient(s)
+  std::vector<double> m_coefficients{}; // Differential case
+  double m_coefficient{};               // Global case
   
-  typedef std::vector<CoefDistr> CoefDistrVec;
-    
-}
-}
+  bool m_is_global{};
+
+public:
+  // Constructors
+  CoefDistr();
+  CoefDistr(const std::string &coef_name, const DistrInfo &info,
+            const std::vector<double> &coefficients);
+  CoefDistr(const std::string &coef_name, const DistrInfo &info,
+            double coefficient);
+
+  // Access functions
+  const std::string &get_coef_name() const;
+  const DistrInfo &get_info() const;
+  double get_coef(int bin) const;
+};
+
+using CoefDistrVec = std::vector<CoefDistr>;
+
+} // namespace Data
+} // namespace PrEW
 
 #endif

--- a/source/prew/include/Data/DiffDistr.h
+++ b/source/prew/include/Data/DiffDistr.h
@@ -25,6 +25,8 @@ namespace Data {
     //    doesn't need it
     CppUtils::Vec::Matrix2D<double> m_bin_centers {}; 
     Fit::BinVec m_distribution {}; // Distribution of number of events
+    
+    const DistrInfo & get_info() const { return m_info; }
   };
   
   typedef std::vector<DiffDistr> DiffDistrVec;

--- a/source/prew/include/Data/DistrUtils.tpp
+++ b/source/prew/include/Data/DistrUtils.tpp
@@ -25,8 +25,8 @@ std::vector<T> DistrUtils::subvec_energy_and_name(
   
   // Lambda comparison checking energy and name match for single distribution
   auto info_comparison = [energy, distr_name](const T& distr) { 
-                          return (distr.m_info.m_energy == energy) &&
-                                 (distr.m_info.m_distr_name == distr_name);
+                          return (distr.get_info().m_energy == energy) &&
+                                 (distr.get_info().m_distr_name == distr_name);
                           };
   
   // Return all distributions where energy and name match
@@ -46,7 +46,7 @@ std::vector<T> DistrUtils::subvec_energy(
   
   // Lambda comparison checking energy match for single distribution
   auto info_comparison =  [energy](const T& distr) { 
-                            return (distr.m_info.m_energy == energy);
+                            return (distr.get_info().m_energy == energy);
                           };
   
   // Return all distributions where energy match
@@ -65,7 +65,7 @@ std::vector<T> DistrUtils::subvec_pol(
   
   // Lambda comparison checking polarisation match for single distribution
   auto info_comparison = [pol_config](const T& distr) { 
-                            return (distr.m_info.m_pol_config == pol_config);
+                            return (distr.get_info().m_pol_config == pol_config);
                           };
   
   // Return all matching distributions

--- a/source/prew/include/Data/PredDistr.h
+++ b/source/prew/include/Data/PredDistr.h
@@ -20,6 +20,8 @@ namespace Data {
     CppUtils::Vec::Matrix2D<double> m_bin_centers {}; 
     std::vector<double> m_sig_distr {}; // Predicted signal distribution
     std::vector<double> m_bkg_distr {}; // Predicted background distribution
+    
+    const DistrInfo & get_info() const { return m_info; }
   };
   
   typedef std::vector<PredDistr> PredDistrVec;

--- a/source/prew/include/Data/PredLink.h
+++ b/source/prew/include/Data/PredLink.h
@@ -19,6 +19,7 @@ namespace Data {
     FctLinkVec m_fcts_links_sig {}; // Modification of signal Xsection
     FctLinkVec m_fcts_links_bkg {}; // Modification of bkg Xsection 
     
+    const DistrInfo & get_info() const { return m_info; }
   };
   
   using PredLinkVec = std::vector<PredLink>;

--- a/source/prew/src/Connect/Linker.cpp
+++ b/source/prew/src/Connect/Linker.cpp
@@ -56,10 +56,10 @@ std::function<double()> Linker::get_bonded_fct_at_bin (
   for ( const auto & coef_name: fct_link.m_coefs ) {
     // Find coefficient distribution with given name
     auto name_condition = [coef_name](const Data::CoefDistr& coef_distr) 
-                            {return coef_distr.m_coef_name==coef_name;};
+                            {return coef_distr.get_coef_name()==coef_name;};
     auto coefs = CppUtils::Vec::element_by_condition(m_coefs, name_condition);
     // Choose coeffient value at bin
-    bin_coefs.push_back(coefs.m_coefficients[bin]);
+    bin_coefs.push_back(coefs.get_coef(bin));
   }
   spdlog::debug("Found {} coefficients.", bin_coefs.size());
   

--- a/source/prew/src/Data/CoefDistr.cpp
+++ b/source/prew/src/Data/CoefDistr.cpp
@@ -1,0 +1,50 @@
+#include <Data/CoefDistr.h>
+
+#include <stdexcept>
+
+namespace PrEW {
+namespace Data {
+
+//------------------------------------------------------------------------------
+// Constructors
+
+CoefDistr::CoefDistr() {}
+
+CoefDistr::CoefDistr(const std::string &coef_name, const DistrInfo &info,
+                     const std::vector<double> &coefficients)
+    : m_coef_name(coef_name), m_info(info), m_coefficients(coefficients),
+      m_is_global(false) {
+  /** Constructor using differential coefficients (different for each bin).
+   **/
+}
+
+CoefDistr::CoefDistr(const std::string &coef_name, const DistrInfo &info,
+                     double coefficient)
+    : m_coef_name(coef_name), m_info(info), m_coefficient(coefficient),
+      m_is_global(true) {
+  /** Constructor using a global coefficient (same for each bin).
+   **/
+}
+
+//------------------------------------------------------------------------------
+// Access functions
+
+const std::string &CoefDistr::get_coef_name() const { return m_coef_name; }
+const DistrInfo &CoefDistr::get_info() const { return m_info; }
+
+double CoefDistr::get_coef(int bin) const {
+  /** Returns the coefficient for the given bin of the distribution.
+   **/
+  if (!m_is_global) {
+    if (bin >= int(m_coefficients.size())) {
+      throw std::out_of_range("CoefDistr: requested bin out of range: " +
+                              std::to_string(bin));
+    }
+  }
+  return m_is_global ? m_coefficient : m_coefficients[bin];
+}
+
+//------------------------------------------------------------------------------
+
+} // Namespace Data
+} // Namespace PrEW

--- a/source/prew/src/Input/Reading.cpp
+++ b/source/prew/src/Input/Reading.cpp
@@ -113,17 +113,8 @@ void Reading::read_RK_file(
     std::vector<std::string> coef_labels = CppUtils::Str::string_to_vec( *diff_TGC_coeff_label, ";");
     size_t n_coefs = coef_labels.size();
     
-    Data::CoefDistrVec coefs_LL (n_coefs), coefs_LR (n_coefs), coefs_RL (n_coefs), coefs_RR (n_coefs);
-    for (size_t c=0; c<n_coefs; c++) { 
-      coefs_LL[c].m_coef_name = coef_labels[c];
-      coefs_LR[c].m_coef_name = coef_labels[c];
-      coefs_RL[c].m_coef_name = coef_labels[c];
-      coefs_RR[c].m_coef_name = coef_labels[c];
-      coefs_LL[c].m_info = info_LL;
-      coefs_LR[c].m_info = info_LR;
-      coefs_RL[c].m_info = info_RL;
-      coefs_RR[c].m_info = info_RR;
-    }
+    std::vector<std::vector<double>> coef_vals_LL (n_coefs), 
+      coef_vals_LR (n_coefs), coef_vals_RL (n_coefs), coef_vals_RR (n_coefs);
     
     for (int bin=0; bin<n_bins; bin++) {
       pred_LL.m_sig_distr.push_back( diff_sigma_signal_LL[bin] );
@@ -132,11 +123,19 @@ void Reading::read_RK_file(
       pred_RR.m_sig_distr.push_back( diff_sigma_signal_RR[bin] );
       
       for (size_t coef=0; coef<n_coefs; coef++) {
-        coefs_LL[coef].m_coefficients.push_back((*diff_TGC_coeff_LL)[bin][coef]);
-        coefs_LR[coef].m_coefficients.push_back((*diff_TGC_coeff_LR)[bin][coef]);
-        coefs_RL[coef].m_coefficients.push_back((*diff_TGC_coeff_RL)[bin][coef]);
-        coefs_RR[coef].m_coefficients.push_back((*diff_TGC_coeff_RR)[bin][coef]);
+        coef_vals_LL[coef].push_back((*diff_TGC_coeff_LL)[bin][coef]);
+        coef_vals_LR[coef].push_back((*diff_TGC_coeff_LR)[bin][coef]);
+        coef_vals_RL[coef].push_back((*diff_TGC_coeff_RL)[bin][coef]);
+        coef_vals_RR[coef].push_back((*diff_TGC_coeff_RR)[bin][coef]);
       }
+    }
+    
+    Data::CoefDistrVec coefs_LL (n_coefs), coefs_LR (n_coefs), coefs_RL (n_coefs), coefs_RR (n_coefs);
+    for (size_t c=0; c<n_coefs; c++) { 
+      coefs_LL[c] = Data::CoefDistr(coef_labels[c],info_LL,coef_vals_LL[c]);
+      coefs_LR[c] = Data::CoefDistr(coef_labels[c],info_LR,coef_vals_LR[c]);
+      coefs_RL[c] = Data::CoefDistr(coef_labels[c],info_RL,coef_vals_RL[c]);
+      coefs_RR[c] = Data::CoefDistr(coef_labels[c],info_RR,coef_vals_RR[c]);
     }
     
     // RK style files don't contain background distributions => 0-entry vectors

--- a/source/tests/Data/test_CoefDistr.cpp
+++ b/source/tests/Data/test_CoefDistr.cpp
@@ -1,0 +1,48 @@
+#include <gtest/gtest.h>
+
+#include <CppUtils/Num.h>
+#include <Data/CoefDistr.h>
+#include <Data/DistrInfo.h>
+
+#include <string>
+#include <vector>
+
+using namespace PrEW::CppUtils;
+using namespace PrEW::Data;
+
+//------------------------------------------------------------------------------
+// Tests for DistrInfo class
+
+TEST(TestCoefDistr, TrivialConstructor) {
+  CoefDistr coefs {};
+  ASSERT_STREQ(coefs.get_coef_name().c_str(), "");
+  ASSERT_EQ(coefs.get_info(), DistrInfo());
+  ASSERT_THROW(coefs.get_coef(0),std::out_of_range);
+}
+
+//------------------------------------------------------------------------------
+
+TEST(TestCoefDistr, GlobalAndDiffCoefs) {
+  std::string test_name = "Name";
+  DistrInfo test_info = {"Distr", "PolConfig", 1000};
+  
+  double test_val = 1.25;
+  std::vector<double> test_vals {-0.234, 213213, 444, 222.004};
+  
+  CoefDistr coef(test_name,test_info,test_val);
+  CoefDistr coefs(test_name,test_info,test_vals);
+  
+  ASSERT_STREQ(coef.get_coef_name().c_str(), test_name.c_str());
+  ASSERT_STREQ(coefs.get_coef_name().c_str(), test_name.c_str());
+  ASSERT_EQ(coef.get_info(), test_info);
+  ASSERT_EQ(coefs.get_info(), test_info);
+  
+  for (size_t b=0; b<test_vals.size(); b++) {
+    ASSERT_EQ( Num::equal_to_eps(coef.get_coef(b), test_val), true )
+      << "Got: " << coef.get_coef(b) << ", expected: " << test_val;
+    ASSERT_EQ( Num::equal_to_eps(coefs.get_coef(b), test_vals[b]), true )
+      << "Got: " << coefs.get_coef(b) << ", expected: " << test_vals[b];
+  }
+}
+
+//------------------------------------------------------------------------------

--- a/source/tests/Input/test_DataReader.cpp
+++ b/source/tests/Input/test_DataReader.cpp
@@ -50,7 +50,7 @@ TEST(TestDataReader, TestRKFileReading) {
   
   // Check that all coefficients are named
   for (const auto & coef: prediction_coefficients) {
-    ASSERT_EQ( (coef.m_coef_name == ""), false );
+    ASSERT_EQ( (coef.get_coef_name() == ""), false );
   }
 
 }


### PR DESCRIPTION
- Change CoefDistr from a simple struct to a class that allows both 
distribution-global and differential coefficients.
- Add test for the adjusted CoefDistr class.
- Add trivial get_info function to the structs in the Data namespace to 
allow same kind of access as for CoefDistr.
- Adjust PrEW to change of CoefDistr class and to new common get_info 
access funciton.