### PR TITLE
Prepare for refactoring of PrEWUtils 

### DIFF
--- a/source/prew/include/Data/CoefDistr.h
+++ b/source/prew/include/Data/CoefDistr.h
@@ -32,10 +32,17 @@ public:
   CoefDistr(const std::string &coef_name, const DistrInfo &info,
             double coefficient);
 
+  // Manipulation funcitons
+  void set_info(const DistrInfo & info);
+
   // Access functions
   const std::string &get_coef_name() const;
   const DistrInfo &get_info() const;
   double get_coef(int bin) const;
+  
+  // Operators
+  bool operator==(const CoefDistr& other) const;
+  bool operator!=(const CoefDistr& other) const;
 };
 
 using CoefDistrVec = std::vector<CoefDistr>;

--- a/source/prew/include/Data/DistrInfo.h
+++ b/source/prew/include/Data/DistrInfo.h
@@ -2,6 +2,7 @@
 #define LIB_DISTRINFO_H 1
 
 #include <string>
+#include <vector>
 
 namespace PrEW {
 namespace Data {
@@ -16,6 +17,7 @@ namespace Data {
     bool operator==(const DistrInfo& other) const;
   };
   
+  using InfoVec = std::vector<DistrInfo>;
 }
 }
 

--- a/source/prew/include/Data/DistrUtils.h
+++ b/source/prew/include/Data/DistrUtils.h
@@ -39,6 +39,8 @@ namespace DistrUtils {
   
   DiffDistr combine_bins(const DiffDistr & distr);
   PredDistr combine_bins(const PredDistr & distr);
+  PredDistrVec combine_bins(const PredDistrVec & distrs);
+  
   
 } // Namespace DistrUtils
   

--- a/source/prew/include/Data/DistrUtils.h
+++ b/source/prew/include/Data/DistrUtils.h
@@ -18,6 +18,8 @@ namespace DistrUtils {
   **/
   
   template<class T>
+  std::vector<T> subvec_info(const std::vector<T>& vec, const DistrInfo &info);
+  template<class T>
   std::vector<T> subvec_energy_and_name(const std::vector<T>& vec, 
                                         int energy, 
                                         std::string distr_name);

--- a/source/prew/include/Data/DistrUtils.tpp
+++ b/source/prew/include/Data/DistrUtils.tpp
@@ -109,13 +109,13 @@ T DistrUtils::element_pol(
   
   // Check for how many are found
   if ( all_pol_elements.size() == 0 ) {
-    spdlog::warn("Vector doesn't have element of pol. {}", pol_config);
+    spdlog::debug("Vector doesn't have element of pol. {}", pol_config);
   } else {
     output_element = all_pol_elements.at(0);
   }
   
   if ( all_pol_elements.size() > 1 ) {
-    spdlog::warn(
+    spdlog::debug(
       "Vector has more than one element of pol. {} , returning first", 
       pol_config
     );

--- a/source/prew/include/Data/DistrUtils.tpp
+++ b/source/prew/include/Data/DistrUtils.tpp
@@ -14,6 +14,26 @@ namespace Data {
 //------------------------------------------------------------------------------
 
 template<class T>
+std::vector<T> DistrUtils::subvec_info(
+  const std::vector<T>& vec, 
+  const DistrInfo &info
+) {
+  /** Find sub-vector of vector vec in which only distributions are contained 
+      whose info is equal to the given info.
+  **/
+  
+  // Lambda comparison checking energy and name match for single distribution
+  auto info_comparison = [info](const T &distr) {
+    return distr.get_info() == info;
+  };
+  
+  // Return all distributions where energy and name match
+  return CppUtils::Vec::subvec_by_condition( vec, info_comparison ); 
+}
+
+//------------------------------------------------------------------------------
+
+template<class T>
 std::vector<T> DistrUtils::subvec_energy_and_name(
   const std::vector<T>& vec, 
   int energy, 

--- a/source/prew/src/Connect/Linker.cpp
+++ b/source/prew/src/Connect/Linker.cpp
@@ -45,6 +45,7 @@ std::function<double()> Linker::get_bonded_fct_at_bin (
   spdlog::debug("Looking for {} coefficients.", fct_link.m_coefs.size());
   std::vector<double> bin_coefs {};
   for ( const auto & coef_name: fct_link.m_coefs ) {
+    spdlog::debug("Looking for coefficient: {}", coef_name);
     // Find coefficient distribution with given name
     auto name_condition = [coef_name](const Data::CoefDistr& coef_distr) 
                             {return coef_distr.get_coef_name()==coef_name;};
@@ -52,7 +53,11 @@ std::function<double()> Linker::get_bonded_fct_at_bin (
     // Choose coeffient value at bin
     bin_coefs.push_back(coefs.get_coef(bin));
   }
-  spdlog::debug("Found {} coefficients.", bin_coefs.size());
+  if ( fct_link.m_coefs.size() != bin_coefs.size() ) {
+    throw std::invalid_argument(
+        "Was looking for " + std::to_string(fct_link.m_coefs.size()) +
+        " coefficients and found " + std::to_string(bin_coefs.size()) + ".");
+  }
   
   // Find pointers to needed parameters
   spdlog::debug("Looking for {} parameters.", fct_link.m_pars.size());

--- a/source/prew/src/Data/CoefDistr.cpp
+++ b/source/prew/src/Data/CoefDistr.cpp
@@ -27,6 +27,11 @@ CoefDistr::CoefDistr(const std::string &coef_name, const DistrInfo &info,
 }
 
 //------------------------------------------------------------------------------
+// Manipulation functions
+
+void CoefDistr::set_info(const DistrInfo &info) { m_info = info; }
+
+//------------------------------------------------------------------------------
 // Access functions
 
 const std::string &CoefDistr::get_coef_name() const { return m_coef_name; }
@@ -42,6 +47,21 @@ double CoefDistr::get_coef(int bin) const {
     }
   }
   return m_is_global ? m_coefficient : m_coefficients[bin];
+}
+
+//------------------------------------------------------------------------------
+// Operators
+
+bool CoefDistr::operator==(const CoefDistr &other) const {
+  /** Identity of coefficient defined by its name the assigned distribution
+      info.
+   **/
+  return (this->get_coef_name() == other.get_coef_name()) &&
+         (this->get_info() == other.get_info());
+}
+
+bool CoefDistr::operator!=(const CoefDistr &other) const {
+  return !(*this == other);
 }
 
 //------------------------------------------------------------------------------

--- a/source/prew/src/Data/DistrUtils.cpp
+++ b/source/prew/src/Data/DistrUtils.cpp
@@ -95,5 +95,17 @@ PredDistr DistrUtils::combine_bins(const PredDistr &distr) {
 
 //------------------------------------------------------------------------------
 
+PredDistrVec DistrUtils::combine_bins(const PredDistrVec &distrs) {
+  /** Combine the bins for each distribution in the vector.
+   **/
+  PredDistrVec new_distrs{};
+  for (const auto &distr : distrs) {
+    new_distrs.push_back(combine_bins(distr));
+  }
+  return new_distrs;
+}
+
+//------------------------------------------------------------------------------
+
 } // Namespace Data
 } // Namespace PrEW

--- a/source/tests/Data/test_CoefDistr.cpp
+++ b/source/tests/Data/test_CoefDistr.cpp
@@ -22,6 +22,16 @@ TEST(TestCoefDistr, TrivialConstructor) {
 
 //------------------------------------------------------------------------------
 
+TEST(TestCoefDistr, ChangeInfo) {
+  CoefDistr coefs {};
+  ASSERT_EQ(coefs.get_info(), DistrInfo());
+  DistrInfo test_info = {"Distr", "PolConfig", 1000};
+  coefs.set_info(test_info);
+  ASSERT_EQ(coefs.get_info(), test_info);
+}
+
+//------------------------------------------------------------------------------
+
 TEST(TestCoefDistr, GlobalAndDiffCoefs) {
   std::string test_name = "Name";
   DistrInfo test_info = {"Distr", "PolConfig", 1000};
@@ -43,6 +53,21 @@ TEST(TestCoefDistr, GlobalAndDiffCoefs) {
     ASSERT_EQ( Num::equal_to_eps(coefs.get_coef(b), test_vals[b]), true )
       << "Got: " << coefs.get_coef(b) << ", expected: " << test_vals[b];
   }
+}
+
+//------------------------------------------------------------------------------
+
+TEST(TestCoefDistr, Operators) {
+  DistrInfo info_A = {"DistrA", "PolConfigA", 1000};
+  DistrInfo info_B = {"DistrB", "PolConfigB", 1000};
+  CoefDistr coef1("CoefA",info_A,0);
+  CoefDistr coef2("CoefA",info_A,{1,2,3});
+  CoefDistr coef3("CoefA",info_B,0);
+  CoefDistr coef4("CoefB",info_A,0);
+  
+  ASSERT_EQ(coef1, coef2);
+  ASSERT_NE(coef1, coef3);
+  ASSERT_NE(coef1, coef4);
 }
 
 //------------------------------------------------------------------------------

--- a/source/tests/Data/test_DistrUtils.cpp
+++ b/source/tests/Data/test_DistrUtils.cpp
@@ -172,15 +172,35 @@ TEST(TestDistrUtils, CombinePredDistr) {
   double comb_bkg = comb_distr.m_bkg_distr[0];
   
   for (size_t d=0; d<bin_middle.size(); d++) {
-    EXPECT_EQ( Num::equal_to_eps( bin_middle[d], bin_centers[d] ), true  ) 
+    ASSERT_EQ( Num::equal_to_eps( bin_middle[d], bin_centers[d] ), true  ) 
     << "Expected " << bin_middle[d] << " got " << bin_centers[d];
   } 
   
-  EXPECT_EQ( Num::equal_to_eps( sig_sum, comb_sig ), true ) 
+  ASSERT_EQ( Num::equal_to_eps( sig_sum, comb_sig ), true ) 
     << "Expected " << sig_sum << " got " << comb_sig;
   
-  EXPECT_EQ( Num::equal_to_eps( bkg_sum, comb_bkg ), true  ) 
+  ASSERT_EQ( Num::equal_to_eps( bkg_sum, comb_bkg ), true  ) 
     << "Expected " << bkg_sum << " got " << comb_bkg;
+  
+  // ****
+  // Exact same test for a vector of distribtions
+  PredDistrVec distrs {distr, distr};
+  auto comb_distrs = DistrUtils::combine_bins(distrs);
+  for (const auto &_comb_distr: comb_distrs) {
+    auto _bin_centers = _comb_distr.m_bin_centers[0];
+    double _comb_sig = _comb_distr.m_sig_distr[0];
+    double _comb_bkg = _comb_distr.m_bkg_distr[0];
+    
+    for (size_t d=0; d<bin_middle.size(); d++) {
+      EXPECT_EQ( Num::equal_to_eps( bin_middle[d], _bin_centers[d] ), true  ) 
+      << "Expected " << bin_middle[d] << " got " << _bin_centers[d];
+    } 
+    EXPECT_EQ( Num::equal_to_eps( sig_sum, _comb_sig ), true ) 
+      << "Expected " << sig_sum << " got " << _comb_sig;
+    EXPECT_EQ( Num::equal_to_eps( bkg_sum, _comb_bkg ), true  ) 
+      << "Expected " << bkg_sum << " got " << _comb_bkg;
+  }
+
 }
 
 //------------------------------------------------------------------------------

--- a/source/tests/Data/test_DistrUtils.cpp
+++ b/source/tests/Data/test_DistrUtils.cpp
@@ -15,6 +15,23 @@ using namespace PrEW::Data;
 //------------------------------------------------------------------------------
 // Tests for distribution helper functions
 
+TEST(TestDistrUtils, SubVecInfo) {
+  // Test if distributions are correctly extracted by their info
+  DistrInfo info1 {"D1","LR",200};
+  DistrInfo info2 {"D2","RL",400};
+  
+  DiffDistrVec vec {
+    {info1, {}, {}},
+    {info1, {}, {}},
+    {info1, {}, {}},
+    {info2, {}, {}},
+    {info2, {}, {}},
+  };
+  
+  // Should extract exactly 3 distributions named "d1" with energy 200
+  ASSERT_EQ(DistrUtils::subvec_info(vec,info1).size(), 3);
+}
+
 TEST(TestDistrUtils, SubVecEnergyName) {
   // Test if distributions are correctly extracted by their name and energy
   std::string good_name = "d1";


### PR DESCRIPTION
- Add more debug output in DataConnector and Linker.
- Add the possibility to set the info of a CoefDistr after construction.
- Add equal/not-equal operators for CoefDistr.
- Add tests for new set function and operators of CoefDistr.
- Add shortcut DistrInfoVec.
- Add a function to search some data vector for the subvector with a specific info.
- Add test for vector info search.
- Switch the warning output of the pol element search to debug (not that crucial, can happen).
- Add bin combination function for PredDistrVec.
- Add test for bin combination function for PredDistrVec.