### PR TITLE
Enable CSV coefficient input

### DIFF
--- a/source/prew/include/Data/PredDistr.h
+++ b/source/prew/include/Data/PredDistr.h
@@ -22,6 +22,13 @@ namespace Data {
     std::vector<double> m_bkg_distr {}; // Predicted background distribution
     
     const DistrInfo & get_info() const { return m_info; }
+    
+    bool operator==(const PredDistr &other) const {
+      return (m_info == other.m_info) && 
+             (m_bin_centers == other.m_bin_centers) &&
+             (m_sig_distr == other.m_sig_distr) &&
+             (m_bkg_distr == other.m_bkg_distr);
+    }
   };
   
   typedef std::vector<PredDistr> PredDistrVec;

--- a/source/prew/include/Input/CSVInterpreter.h
+++ b/source/prew/include/Input/CSVInterpreter.h
@@ -1,0 +1,55 @@
+#ifndef LIB_CSVINTERPRETER_H
+#define LIB_CSVINTERPRETER_H 1
+
+#include <Data/CoefDistr.h>
+#include <Data/DistrInfo.h>
+#include <Data/PredDistr.h>
+#include <Input/CSVMetadata.h>
+
+// Standard library
+#include <string>
+#include <vector>
+
+#include "csv.hpp"
+
+namespace PrEW {
+namespace Input {
+
+class CSVInterpreter {
+  /** Class that interprets a CSV file containing all the information for one
+   *distribution and the metadata of the distribution.
+   **/
+
+  Data::DistrInfo m_info{};
+  Data::PredDistr m_pred_distr{};
+  Data::CoefDistrVec m_coef_distrs{};
+  
+  // Markers used in column headers
+  const std::string BinCenterMarker {"BinCenters"};
+  const std::string CoefficientMarker {"Coef"};
+
+public:
+  // Constructors
+  CSVInterpreter(const std::string &file_path);
+  
+  // Access functions
+  const Data::DistrInfo & get_info() const;
+  const Data::PredDistr & get_pred_distr() const;
+  const Data::CoefDistrVec & get_coef_distrs() const;
+
+protected:
+  void read_metadata(const CSVMetadata &metadata);
+  void read_csv(csv::CSVReader &csv_reader);
+
+  std::vector<std::string>
+  find_bin_centers(const std::vector<std::string> &col_names);
+  std::vector<std::string>
+  find_coefs(const std::vector<std::string> &col_names);
+
+  bool col_fits_key(const std::string &col_name, const std::string &key);
+};
+
+} // namespace Input
+} // namespace PrEW
+
+#endif

--- a/source/prew/src/Connect/DataConnector.cpp
+++ b/source/prew/src/Connect/DataConnector.cpp
@@ -2,6 +2,7 @@
 #include <Connect/Linker.h>
 #include <Connect/LinkHelp.h>
 #include <Data/DistrUtils.h>
+#include <Data/PredDistr.h>
 #include <GlobalVar/Chiral.h>
 
 #include "spdlog/spdlog.h"
@@ -135,6 +136,43 @@ void DataConnector::fill_bins(
                                                 GlobalVar::Chiral::eLpL);
   auto coefs_RR = Data::DistrUtils::subvec_pol( coefficients, 
                                                 GlobalVar::Chiral::eRpR);
+  // ---------------------------------------------------------------------------
+  
+  // --- Check if any chiral distributions are missing -------------------------
+  // Not every chiral distribution has to be provided.
+  // Those that aren't will be assumed as 0.
+  
+  std::vector<double> zero_distr (bin_centers.size(), 0.0);
+  int n_not_found = 0;
+  if (pred_LR == Data::PredDistr()) {
+    spdlog::debug("No LR prediction available for {}, assume zero.", distr_name);
+    pred_LR.m_sig_distr = zero_distr;
+    pred_LR.m_bkg_distr = zero_distr;
+    n_not_found++;
+  }
+  if (pred_RL == Data::PredDistr()) {
+    spdlog::debug("No RL prediction available for {}, assume zero.", distr_name);
+    pred_RL.m_sig_distr = zero_distr;
+    pred_RL.m_bkg_distr = zero_distr;
+    n_not_found++;
+  }
+  if (pred_LL == Data::PredDistr()) {
+    spdlog::debug("No LL prediction available for {}, assume zero.", distr_name);
+    pred_LL.m_sig_distr = zero_distr;
+    pred_LL.m_bkg_distr = zero_distr;
+    n_not_found++;
+  }
+  if (pred_RR == Data::PredDistr()) {
+    spdlog::debug("No RR prediction available for {}, assume zero.", distr_name);
+    pred_RR.m_sig_distr = zero_distr;
+    pred_RR.m_bkg_distr = zero_distr;
+    n_not_found++;
+  }
+  
+  if (n_not_found == 4) {
+    throw std::invalid_argument("No chiral distr's found for " + distr_name);
+  }
+  
   // ---------------------------------------------------------------------------
 
   // --- Get linkers for chiral alpha functions ------- ------------------------

--- a/source/prew/src/Input/CSVInterpreter.cpp
+++ b/source/prew/src/Input/CSVInterpreter.cpp
@@ -1,0 +1,142 @@
+#include <CppUtils/Str.h>
+#include <CppUtils/Vec.h>
+#include <GlobalVar/Chiral.h>
+#include <Input/CSVInterpreter.h>
+
+// Standard library
+#include <fstream>
+
+namespace PrEW {
+namespace Input {
+
+//------------------------------------------------------------------------------
+
+CSVInterpreter::CSVInterpreter(const std::string &file_path) {
+  /** Constructor interprets the given CSV file (metadata and distribution).
+   **/
+
+  CSVMetadata metadata{};
+  auto csv_reader = metadata.strip_metadata(file_path);
+
+  this->read_metadata(metadata);
+  this->read_csv(csv_reader);
+}
+
+//------------------------------------------------------------------------------
+
+const Data::DistrInfo &CSVInterpreter::get_info() const { return m_info; }
+
+const Data::PredDistr &CSVInterpreter::get_pred_distr() const {
+  return m_pred_distr;
+}
+
+const Data::CoefDistrVec &CSVInterpreter::get_coef_distrs() const {
+  return m_coef_distrs;
+}
+
+//------------------------------------------------------------------------------
+
+void CSVInterpreter::read_metadata(const CSVMetadata &metadata) {
+  /** Use the given metadata to read the distribution info.
+   **/
+  m_info.m_distr_name = metadata.get<std::string>("name");
+  m_info.m_energy = metadata.get<int>("energy");
+  m_info.m_pol_config = GlobalVar::Chiral::transform(
+      metadata.get<int>("e- chirality"), metadata.get<int>("e+ chirality"));
+}
+
+//------------------------------------------------------------------------------
+
+void CSVInterpreter::read_csv(csv::CSVReader &csv_reader) {
+  /** Read the differential distribution and coefficients from the given
+   *CSVReader.
+   **/
+
+  auto col_names = csv_reader.get_col_names();
+  auto bin_center_cols = this->find_bin_centers(col_names);
+  auto coef_cols = this->find_coefs(col_names);
+
+  //
+  CppUtils::Vec::Matrix2D<double> bin_centers{};
+  std::vector<double> bin_values{};
+  std::map<std::string, std::vector<double>> coef_values{};
+
+  // Initialize coefficients vectors
+  for (const auto &coef_col : coef_cols) {
+    coef_values[coef_col] = {};
+  }
+
+  // Collect all the values for the predicted distributions and coefficients
+  for (auto &row : csv_reader) {
+    // Collect bin centers for this bin
+    std::vector<double> bin_center{};
+    for (const auto &bin_center_col : bin_center_cols) {
+      bin_center.push_back(row[bin_center_col].get<double>());
+    }
+    bin_centers.push_back(bin_center);
+
+    // Collect bin values
+    bin_values.push_back(row["Cross sections"].get<double>());
+
+    // Find coefficient vectors
+    for (const auto &coef_col : coef_cols) {
+      coef_values[coef_col].push_back(row[coef_col].get<double>());
+    }
+  }
+
+  // Construct the predicted distribution (no backgrounds contained in CSV file)
+  m_pred_distr = Data::PredDistr{m_info, bin_centers, bin_values,
+                                 std::vector<double>(bin_values.size(), 0.0)};
+
+  // Construct coefficient distributions
+  for (const auto &coef_col : coef_cols) {
+    auto name = CppUtils::Str::string_to_vec(coef_col, ":").at(1);
+    m_coef_distrs.push_back(
+        Data::CoefDistr(name, m_info, coef_values.at(coef_col)));
+  }
+}
+
+//------------------------------------------------------------------------------
+
+std::vector<std::string>
+CSVInterpreter::find_bin_centers(const std::vector<std::string> &col_names) {
+  /** Find the names of bin centers contained in the column headers.
+   **/
+  auto condition = [this](const std::string &col_name) {
+    return this->col_fits_key(col_name, BinCenterMarker);
+  };
+  return CppUtils::Vec::subvec_by_condition(col_names, condition);
+}
+
+//------------------------------------------------------------------------------
+
+std::vector<std::string>
+CSVInterpreter::find_coefs(const std::vector<std::string> &col_names) {
+  /** Find the names of coefficients contained in the column headers.
+   **/
+  auto condition = [this](const std::string &col_name) {
+    return this->col_fits_key(col_name, CoefficientMarker);
+  };
+  return CppUtils::Vec::subvec_by_condition(col_names, condition);
+}
+
+//------------------------------------------------------------------------------
+
+bool CSVInterpreter::col_fits_key(const std::string &col_name,
+                                  const std::string &key) {
+  /** Check if the given column header name fits the given key like "key:...".
+   **/
+  bool fits = false;
+  auto split_str = CppUtils::Str::string_to_vec(col_name, ":");
+
+  if ((split_str.size() == 2) && (split_str.at(0) == key)) {
+    fits = true;
+  }
+
+  return fits;
+}
+
+//------------------------------------------------------------------------------
+
+} // namespace Input
+} // namespace PrEW

--- a/source/prew/src/Input/Reading.cpp
+++ b/source/prew/src/Input/Reading.cpp
@@ -5,13 +5,15 @@
 #include <Fit/FitBin.h>
 #include <GlobalVar/Chiral.h>
 #include <Input/InfoRKFile.h>
-#include <Input/CSVMetadata.h>
+#include <Input/CSVInterpreter.h>
 #include <Input/Reading.h>
 
-#include "spdlog/spdlog.h"
+// Includes from ROOT
 #include "TFile.h"
 #include "TMatrixT.h"
 #include "TTree.h"
+
+#include "spdlog/spdlog.h"
 
 namespace PrEW {
 namespace Input {
@@ -23,34 +25,11 @@ void Reading::read_csv_file(const InputInfo *input_info,
                             Data::CoefDistrVec *coef_distrs) {
   /** Read input CSV file containing info for one chiral distribution.
    **/
-  // Extract metadata and get CSV file reader
-  CSVMetadata metadata;
-  auto csv_reader = metadata.strip_metadata(input_info->m_file_path);
-
-  // Get distribution info
-  Data::DistrInfo info{};
-  info.m_distr_name = metadata.get<std::string>("name");
-  info.m_energy = metadata.get<int>("energy");
-  info.m_pol_config = GlobalVar::Chiral::transform(
-      metadata.get<int>("e- chirality"), metadata.get<int>("e+ chirality"));
-
-  // Read the bins (= rows of the csv file)
-  Data::PredDistr pred_distr{};
-  pred_distr.m_info = info;
-  for (auto &row : csv_reader) {
-    // Find and interpret the bin centers (separated by ":")
-    std::vector<double> bin_centers{};
-    auto center_strs = CppUtils::Str::string_to_vec(
-        row["Bin centers"].get<std::string>(), ":");
-    for (const auto &center : center_strs) {
-      bin_centers.push_back(CppUtils::Str::cast_string<double>(center));
-    }
-
-    // Bin centers and signal 
-    pred_distr.m_bin_centers.push_back(bin_centers);
-    pred_distr.m_sig_distr.push_back(row["Cross sections"].get<double>());
-  }
-  pred_distrs->push_back(pred_distr);
+  CSVInterpreter interpreter(input_info->m_file_path);
+  pred_distrs->push_back(interpreter.get_pred_distr());
+  
+  auto coefs = interpreter.get_coef_distrs();
+  coef_distrs->insert(coef_distrs->end(), coefs.begin(), coefs.end());
 }
 
 //------------------------------------------------------------------------------

--- a/source/tests/Input/test_CSVInterpreter.cpp
+++ b/source/tests/Input/test_CSVInterpreter.cpp
@@ -1,0 +1,35 @@
+#include <gtest/gtest.h>
+
+// Inputs from PrEW
+#include <Data/DistrInfo.h>
+#include <GlobalVar/Chiral.h>
+#include <Input/CSVInterpreter.h>
+
+// Standard library
+#include <string>
+
+using namespace PrEW::Data;
+using namespace PrEW::GlobalVar;
+using namespace PrEW::Input;
+
+//------------------------------------------------------------------------------
+// Tests for CSVInterpreter class
+
+TEST(TestCSVInterpreter, TestDataReading) {
+  CSVInterpreter interpreter("../testdata/test.csv");
+  auto info = interpreter.get_info();
+  auto pred_distr = interpreter.get_pred_distr();
+  auto coef_distrs = interpreter.get_coef_distrs();
+  
+  // Check if info is correct info
+  DistrInfo info_pred {"test", Chiral::eLpR, 250};
+  ASSERT_EQ(info, info_pred);
+  
+  // Contains 2 coefficients
+  ASSERT_EQ(coef_distrs.size(), 2);
+  // Number of bins is 5, bin dimension is 3
+  ASSERT_EQ(pred_distr.m_bin_centers.size(), 5);
+  ASSERT_EQ(pred_distr.m_bin_centers.at(0).size(), 3);
+}
+
+//------------------------------------------------------------------------------

--- a/source/tests/Input/test_DataReader.cpp
+++ b/source/tests/Input/test_DataReader.cpp
@@ -36,11 +36,11 @@ TEST(TestDataReader, TestCSVFileReading) {
   auto predicted_distributions = reader.get_pred_distrs();
   auto prediction_coefficients = reader.get_coef_distrs();
   
-  // CSV files don't contain measurements or coefficients right now
+  // CSV files don't contain measurements
   ASSERT_EQ(measured_distributions.size(), 0); 
-  ASSERT_EQ(prediction_coefficients.size(), 0);
-  // Contains 1 distribution
+  // Contains 1 distribution and 2 coefficients
   ASSERT_EQ(predicted_distributions.size(), 1);
+  ASSERT_EQ(prediction_coefficients.size(), 2);
 }
 
 //------------------------------------------------------------------------------

--- a/testdata/test.csv
+++ b/testdata/test.csv
@@ -4,9 +4,9 @@ Energy: 250
 e-Chirality: -1.0
 e+Chirality: 1.0
 #END-METADATA
-,Bin centers,Cross sections
-0,0.01,0
-1,0.02,1
-2,0.03,2
-3,0.04,3
-4,0.05,4
+,BinCenters:coord1,BinCenters:coord2,BinCenters:coord3,Coef:coef1,Coef:coef2,Cross sections
+0,0.01,-1,1.1,0.4,0.01,0
+1,0.02,-1,1.2,0.3,0.02,1
+2,0.03,-2,1.1,0.2,0.03,2
+3,0.04,-2,1.2,0.1,0.04,3
+4,0.05,-3,1.1,0.0,0.05,4

--- a/testdata/test_without_header.csv
+++ b/testdata/test_without_header.csv
@@ -1,6 +1,6 @@
-,Bin centers,Cross sections
-0,0.01,0
-1,0.02,1
-2,0.03,2
-3,0.04,3
-4,0.05,4
+,BinCenters:coord1,BinCenters:coord2,BinCenters:coord3,Coef:coef1,Coef:coef2,Cross sections
+0,0.01,-1,1.1,0.4,0.01,0
+1,0.02,-1,1.2,0.3,0.02,1
+2,0.03,-2,1.1,0.2,0.03,2
+3,0.04,-2,1.2,0.1,0.04,3
+4,0.05,-3,1.1,0.0,0.05,4


### PR DESCRIPTION
- Add trivial comparison operator to PredDistr.
- Adjust DataConnector to allow only supplying subset of chiral distributions.
- Move CSV Reading in separate CSVInterpreter class and which can also read coefficients.
- Adjust to new bin center and coefficient naming convention.
- Adjust tests for CSV file reading.