### PR TITLE
Allow global coefficients in csv input

### DIFF
--- a/source/prew/include/Input/CSVMetadata.h
+++ b/source/prew/include/Input/CSVMetadata.h
@@ -23,6 +23,7 @@ class CSVMetadata {
       {"Energy", "energy"},
       {"e-Chirality", "e- chirality"},
       {"e+Chirality", "e+ chirality"}};
+  const std::string coef_ID{"Coef"};
 
   // Map holding the metadata strings by its identifiers (to be interpreted)
   std::map<std::string, std::string> m_metadata{};
@@ -39,6 +40,7 @@ public:
   std::vector<std::string> keys() const;
 
 protected:
+  bool ID_is_coef(const std::string & ID_str);
   void interpret(const std::vector<std::string> &metadata_lines);
   std::vector<std::string>
   get_metadata_lines(const std::string &file_path) const;

--- a/source/prew/include/Input/CSVMetadata.h
+++ b/source/prew/include/Input/CSVMetadata.h
@@ -36,6 +36,7 @@ public:
 
   // Access functions
   template <class OutClass> OutClass get(const std::string &name) const;
+  std::vector<std::string> keys() const;
 
 protected:
   void interpret(const std::vector<std::string> &metadata_lines);

--- a/source/prew/include/Input/CSVMetadata.h
+++ b/source/prew/include/Input/CSVMetadata.h
@@ -37,10 +37,10 @@ public:
 
   // Access functions
   template <class OutClass> OutClass get(const std::string &name) const;
-  std::vector<std::string> keys() const;
+  std::vector<std::string> keys(const std::string & which="all") const;
 
 protected:
-  bool ID_is_coef(const std::string & ID_str);
+  bool ID_is_coef(const std::string & ID_str) const;
   void interpret(const std::vector<std::string> &metadata_lines);
   std::vector<std::string>
   get_metadata_lines(const std::string &file_path) const;

--- a/source/prew/src/Input/CSVInterpreter.cpp
+++ b/source/prew/src/Input/CSVInterpreter.cpp
@@ -47,10 +47,19 @@ const Data::CoefDistrVec &CSVInterpreter::get_coef_distrs() const {
 void CSVInterpreter::read_metadata(const CSVMetadata &metadata) {
   /** Use the given metadata to read the distribution info.
    **/
+  // Read the distribution info from the metadata
   m_info.m_distr_name = metadata.get<std::string>("name");
   m_info.m_energy = metadata.get<int>("energy");
   m_info.m_pol_config = GlobalVar::Chiral::transform(
       metadata.get<int>("e- chirality"), metadata.get<int>("e+ chirality"));
+
+  // Look for global coefficients in the metadata
+  for (const auto &coef_ID : metadata.keys("coefs")) {
+    auto coef_name = CppUtils::Str::string_to_vec(coef_ID, "|").at(1);
+    auto coef_val = metadata.get<double>(coef_ID);
+    // Create the global coefficient
+    m_coef_distrs.push_back(Data::CoefDistr(coef_name, m_info, coef_val));
+  }
 }
 
 //------------------------------------------------------------------------------
@@ -82,7 +91,7 @@ void CSVInterpreter::read_csv(csv::CSVReader &csv_reader) {
       edges_low.push_back(row[csv_coord.edge_low()].get<double>());
       edges_up.push_back(row[csv_coord.edge_up()].get<double>());
     }
-    coords.push_back(Data::BinCoord(bin_centers,edges_low,edges_up));
+    coords.push_back(Data::BinCoord(bin_centers, edges_low, edges_up));
 
     // Collect bin values
     bin_values.push_back(row["Cross sections"].get<double>());

--- a/source/prew/src/Input/CSVMetadata.cpp
+++ b/source/prew/src/Input/CSVMetadata.cpp
@@ -44,6 +44,16 @@ std::vector<std::string> CSVMetadata::keys() const {
 
 //------------------------------------------------------------------------------
 
+bool CSVMetadata::ID_is_coef(const std::string &ID_str) {
+  /** Check if the given metadata ID string describes a global coefficient for
+    *the distribution.
+   **/
+  auto split = CppUtils::Str::string_to_vec(ID_str, "|");
+  return (split.size() == 2) && (split.at(0) == CSVMetadata::coef_ID);
+}
+
+//------------------------------------------------------------------------------
+
 void CSVMetadata::interpret(const std::vector<std::string> &metadata_lines) {
   /** Interpret the header lines.
    **/
@@ -61,13 +71,17 @@ void CSVMetadata::interpret(const std::vector<std::string> &metadata_lines) {
     auto ID_str = CppUtils::Str::string_to_vec(split_line[0], ":").at(0);
     auto value = split_line[1];
 
-    if (CSVMetadata::metadata_IDs.find(ID_str) ==
+    // Try to identify and store the value
+    if (CSVMetadata::metadata_IDs.find(ID_str) !=
         CSVMetadata::metadata_IDs.end()) {
+      // Known metadata
+      m_metadata[CSVMetadata::metadata_IDs.at(ID_str)] = value;
+    } else if (this->ID_is_coef(ID_str)) {
+      // It's a global coefficient for this distribution
+      m_metadata[ID_str] = value;
+    } else {
       throw std::invalid_argument("Unknown CSV metadata ID: " + ID_str);
     }
-
-    // Store the value
-    m_metadata[CSVMetadata::metadata_IDs.at(ID_str)] = value;
   }
 }
 

--- a/source/prew/src/Input/CSVMetadata.cpp
+++ b/source/prew/src/Input/CSVMetadata.cpp
@@ -32,6 +32,18 @@ csv::CSVReader CSVMetadata::strip_metadata(const std::string &file_path) {
 
 //------------------------------------------------------------------------------
 
+std::vector<std::string> CSVMetadata::keys() const {
+  /** Return the keys of all the available metadata from the header.
+   **/
+  std::vector<std::string> keys{};
+  for (const auto &[key, _] : m_metadata) {
+    keys.push_back(key);
+  }
+  return keys;
+}
+
+//------------------------------------------------------------------------------
+
 void CSVMetadata::interpret(const std::vector<std::string> &metadata_lines) {
   /** Interpret the header lines.
    **/

--- a/source/tests/Input/test_CSVInterpreter.cpp
+++ b/source/tests/Input/test_CSVInterpreter.cpp
@@ -25,9 +25,9 @@ TEST(TestCSVInterpreter, TestDataReading) {
   DistrInfo info_pred {"test", Chiral::eLpR, 250};
   ASSERT_EQ(info, info_pred);
   
-  // Contains 2 coefficients
-  ASSERT_EQ(coef_distrs.size(), 2);
-  // Number of bins is 5, bin dimension is 3
+  // Contains 4 coefficients (2 differential + 2 global)
+  ASSERT_EQ(coef_distrs.size(), 4);
+  // Number of bins is 5, bin dimension is 2
   ASSERT_EQ(pred_distr.m_coords.size(), 5);
   ASSERT_EQ(pred_distr.m_coords.at(0).get_dim(), 2);
 }

--- a/source/tests/Input/test_CSVMetadata.cpp
+++ b/source/tests/Input/test_CSVMetadata.cpp
@@ -36,7 +36,9 @@ TEST(TestCSVMetadata, TestDataReading) {
   std::vector<std::string> pred_keys{"Coef|Test1",   "Coef|Test2",
                                      "e+ chirality", "e- chirality",
                                      "energy",       "name"};
-  ASSERT_EQ(metadata.keys(), pred_keys);
+  std::vector<std::string> pred_coef_keys{"Coef|Test1",   "Coef|Test2"};
+  ASSERT_EQ(metadata.keys("all"), pred_keys);
+  ASSERT_EQ(metadata.keys("coefs"), pred_coef_keys);
 }
 
 //------------------------------------------------------------------------------

--- a/source/tests/Input/test_CSVMetadata.cpp
+++ b/source/tests/Input/test_CSVMetadata.cpp
@@ -5,6 +5,7 @@
 
 // Standard library
 #include <string>
+#include <vector>
 
 using namespace PrEW::Input;
 
@@ -21,18 +22,24 @@ TEST(TestCSVMetadata, TestDataReading) {
 
   ASSERT_EQ(csv_reader.size(), csv_reader_check.size());
   ASSERT_EQ(csv_reader.get_col_names(), csv_reader_check.get_col_names());
+
   ASSERT_STREQ(metadata.get<std::string>("name").c_str(), "test");
   ASSERT_EQ(metadata.get<int>("energy"), 250);
   ASSERT_EQ(metadata.get<int>("e- chirality"), -1);
   ASSERT_EQ(metadata.get<int>("e+ chirality"), 1);
+
+  // Check that all available keys were read
+  std::vector<std::string> pred_keys{"e+ chirality", "e- chirality", "energy",
+                                     "name"};
+  ASSERT_EQ(metadata.keys(), pred_keys);
 }
 
 //------------------------------------------------------------------------------
 
 TEST(TestCSVMetadata, ThrowExceptionFaultyFiles) {
-  std::string non_existant {"./blablabla"};
+  std::string non_existant{"./blablabla"};
   std::string not_conform{"../testdata/RK_examplefile_500_250_2018_04_03.root"};
-  
+
   CSVMetadata metadata;
   ASSERT_THROW(metadata.strip_metadata(non_existant), std::invalid_argument);
   ASSERT_THROW(metadata.strip_metadata(not_conform), std::invalid_argument);

--- a/source/tests/Input/test_CSVMetadata.cpp
+++ b/source/tests/Input/test_CSVMetadata.cpp
@@ -1,12 +1,14 @@
 #include <gtest/gtest.h>
 
 // Inputs from PrEW
+#include <CppUtils/Num.h>
 #include <Input/CSVMetadata.h>
 
 // Standard library
 #include <string>
 #include <vector>
 
+using namespace PrEW::CppUtils;
 using namespace PrEW::Input;
 
 //------------------------------------------------------------------------------
@@ -27,10 +29,13 @@ TEST(TestCSVMetadata, TestDataReading) {
   ASSERT_EQ(metadata.get<int>("energy"), 250);
   ASSERT_EQ(metadata.get<int>("e- chirality"), -1);
   ASSERT_EQ(metadata.get<int>("e+ chirality"), 1);
+  ASSERT_TRUE(Num::equal_to_eps(metadata.get<double>("Coef|Test1"), 0.001));
+  ASSERT_TRUE(Num::equal_to_eps(metadata.get<double>("Coef|Test2"), -50.5));
 
   // Check that all available keys were read
-  std::vector<std::string> pred_keys{"e+ chirality", "e- chirality", "energy",
-                                     "name"};
+  std::vector<std::string> pred_keys{"Coef|Test1",   "Coef|Test2",
+                                     "e+ chirality", "e- chirality",
+                                     "energy",       "name"};
   ASSERT_EQ(metadata.keys(), pred_keys);
 }
 

--- a/source/tests/Input/test_DataReader.cpp
+++ b/source/tests/Input/test_DataReader.cpp
@@ -38,9 +38,9 @@ TEST(TestDataReader, TestCSVFileReading) {
   
   // CSV files don't contain measurements
   ASSERT_EQ(measured_distributions.size(), 0); 
-  // Contains 1 distribution and 2 coefficients
+  // Contains 1 distribution and 4 coefficients
   ASSERT_EQ(predicted_distributions.size(), 1);
-  ASSERT_EQ(prediction_coefficients.size(), 2);
+  ASSERT_EQ(prediction_coefficients.size(), 4);
 }
 
 //------------------------------------------------------------------------------

--- a/testdata/test.csv
+++ b/testdata/test.csv
@@ -3,6 +3,8 @@ Name: test
 Energy: 250
 e-Chirality: -1.0
 e+Chirality: 1.0
+Coef|Test1: 0.001
+Coef|Test2: -50.5
 #END-METADATA
 ,BinCenters:coord1,BinLow:coord1,BinUp:coord1,BinCenters:coord2,BinLow:coord2,BinUp:coord2,Coef:coef1,Coef:coef2,Cross sections
 0,0.01,0.005,0.015,-1,-1.5,-0.5,0.4,0.01,0


### PR DESCRIPTION
- Add function to get all csv metadata keys and add a test for it.
- Enable reading of global coefficients  in csv metadata class.
- Adjust the csv test file and the csv metadata test to the coefficient reading.
- Adjust csv metadata keys function to allow getting only coefficient keys, and adjust the test accordingly.
- Enable interpretation of global coefficients for a distribution which is read from CSV metadata.
- Adjust csv reading tests to enabled global coefficient reading.