### PR TITLE
Add polynomial acceptance box function

### DIFF
--- a/source/prew/include/Fcts/FctMap.h
+++ b/source/prew/include/Fcts/FctMap.h
@@ -38,7 +38,8 @@ namespace Fcts {
     // Systematic effects
     {"PolarisationFactor", Systematics::polarisation_factor},
     {"LuminosityFraction", Systematics::luminosity_fraction},
-    {"AcceptanceBox", Systematics::acceptance_box}
+    {"AcceptanceBox", Systematics::acceptance_box},
+    {"AcceptanceBoxPolynomial", Systematics::acceptance_box}
   };
 
   

--- a/source/prew/include/Fcts/Systematics.h
+++ b/source/prew/include/Fcts/Systematics.h
@@ -33,6 +33,10 @@ namespace Systematics {
                          const std::vector<double>   &c,
                          const std::vector<double*>  &p);
     
+  double acceptance_box_polynomial (const Data::BinCoord       &x,
+                                    const std::vector<double>  &c,
+                                    const std::vector<double*> &p);
+    
   //----------------------------------------------------------------------------
   
 } // Namespace Systematics

--- a/source/prew/src/Fcts/Systematics.cpp
+++ b/source/prew/src/Fcts/Systematics.cpp
@@ -88,57 +88,32 @@ double Systematics::acceptance_box (
 //------------------------------------------------------------------------------
 
 double Systematics::acceptance_box_polynomial (
-  const Data::BinCoord &x,
+  const Data::BinCoord &/*x*/,
   const std::vector<double>   &c,
   const std::vector<double*>  &p
 ) {
   /** Calculate factor from detector acceptance for box-like detector 
-      acceptance in a given coordinate.
+      acceptance.
       Small deviations of the edges on both sides of the box lead to deviations
       which are described by a second order polynomial. The coefficients for 
       that polynomial should be calculated from Monte Carlo events.
-      Additional restrictions are put that bins completely outside (inside) of 
-      acceptance are exactly 0 (1) and the factor only be between 0 and 1.
-      Coordinates: x[c[0]] - coordinate of the acceptance range
-      Coefficients: c[0] - index of the relevant coordinate (must be int!)
-                    c[1] - the initial cut value (symmetric on + and - side)
-                    c[2] - constant polynomial term
-                    c[3] - linear polyn. term in center deviation
-                    c[4] - linear polyn. term in width deviation
-                    c[5] - quadratic polyn. term in center deviation
-                    c[6] - quadratic polyn. term in width deviation
-                    c[7] - mixed polynomial term in width and center deviations
+      An additional restriction is applied so that the factor can only be 
+      between 0 and 1.
+      Coefficients: c[0] - constant polynomial term
+                    c[1] - linear polyn. term in center deviation
+                    c[2] - linear polyn. term in width deviation
+                    c[3] - quadratic polyn. term in center deviation
+                    c[4] - quadratic polyn. term in width deviation
+                    c[5] - mixed polynomial term in width and center deviations
       Parameters: p[0] - deviation in the box center
                   p[1] - deviation in the box width
   **/
-  int coord_index = int(c[0]);
-  double edge_low = x.get_edge_low()[coord_index];
-  double edge_up = x.get_edge_up()[coord_index];
-  
-  double initial_cut = c[1];
   double dc = (*(p[0]));
   double dw = (*(p[1]));
-  double cut_low = - initial_cut + dc - dw/2.0;
-  double cut_up = initial_cut + dc + dw/2.0;
   
-  double factor = 0;
-  
-  if ( edge_up < cut_low ) {
-    // Bin completely outside of acceptance on negative side
-    factor = 0.0;
-  } else if ( edge_low > cut_up ) {
-    // Bin completely outside of acceptance on positive side
-    factor = 0.0;
-  } else if ( (edge_low > cut_low) && (edge_up < cut_up) ) {
-    // Bin completely inside acceptance
-    factor = 1.0;
-  } else {
-    // Bin is partially in acceptance, apply polynomial
-    factor = c[2] 
-             + c[3] * dc + c[4] * dw
-             + c[5] * std::pow(dc,2) + c[6] * std::pow(dw,2)
-             + c[7] * dc * dw;
-  }
+  double factor = c[0] + c[1] * dc + c[2] * dw
+                  + c[3] * std::pow(dc,2) + c[4] * std::pow(dw,2)
+                  + c[5] * dc * dw;
   
   // Enforce that the factor can only be between 0 and 1
   if (factor > 1) {

--- a/source/prew/src/Fcts/Systematics.cpp
+++ b/source/prew/src/Fcts/Systematics.cpp
@@ -1,5 +1,8 @@
 #include <Fcts/Systematics.h>
 
+// Standard library
+#include <cmath>
+
 namespace PrEW {
 namespace Fcts {
 
@@ -77,6 +80,71 @@ double Systematics::acceptance_box (
   } else if ( ( edge_up > bin_min) && ( edge_up < bin_max) ) {
     // Upper edge within bin
     factor = ( edge_up - bin_min ) / bin_width;
+  }
+  
+  return factor;
+}
+
+//------------------------------------------------------------------------------
+
+double Systematics::acceptance_box_polynomial (
+  const Data::BinCoord &x,
+  const std::vector<double>   &c,
+  const std::vector<double*>  &p
+) {
+  /** Calculate factor from detector acceptance for box-like detector 
+      acceptance in a given coordinate.
+      Small deviations of the edges on both sides of the box lead to deviations
+      which are described by a second order polynomial. The coefficients for 
+      that polynomial should be calculated from Monte Carlo events.
+      Additional restrictions are put that bins completely outside (inside) of 
+      acceptance are exactly 0 (1) and the factor only be between 0 and 1.
+      Coordinates: x[c[0]] - coordinate of the acceptance range
+      Coefficients: c[0] - index of the relevant coordinate (must be int!)
+                    c[1] - the initial cut value (symmetric on + and - side)
+                    c[2] - constant polynomial term
+                    c[3] - linear polyn. term in center deviation
+                    c[4] - linear polyn. term in width deviation
+                    c[5] - quadratic polyn. term in center deviation
+                    c[6] - quadratic polyn. term in width deviation
+                    c[7] - mixed polynomial term in width and center deviations
+      Parameters: p[0] - deviation in the box center
+                  p[1] - deviation in the box width
+  **/
+  int coord_index = int(c[0]);
+  double edge_low = x.get_edge_low()[coord_index];
+  double edge_up = x.get_edge_up()[coord_index];
+  
+  double initial_cut = c[1];
+  double dc = (*(p[0]));
+  double dw = (*(p[1]));
+  double cut_low = - initial_cut + dc - dw/2.0;
+  double cut_up = initial_cut + dc + dw/2.0;
+  
+  double factor = 0;
+  
+  if ( edge_up < cut_low ) {
+    // Bin completely outside of acceptance on negative side
+    factor = 0.0;
+  } else if ( edge_low > cut_up ) {
+    // Bin completely outside of acceptance on positive side
+    factor = 0.0;
+  } else if ( (edge_low > cut_low) && (edge_up < cut_up) ) {
+    // Bin completely inside acceptance
+    factor = 1.0;
+  } else {
+    // Bin is partially in acceptance, apply polynomial
+    factor = c[2] 
+             + c[3] * dc + c[4] * dw
+             + c[5] * std::pow(dc,2) + c[6] * std::pow(dw,2)
+             + c[7] * dc * dw;
+  }
+  
+  // Enforce that the factor can only be between 0 and 1
+  if (factor > 1) {
+    factor = 1.0;
+  } else if (factor < 0) {
+    factor = 0.0;
   }
   
   return factor;

--- a/source/tests/Fcts/test_Systematics.cpp
+++ b/source/tests/Fcts/test_Systematics.cpp
@@ -89,3 +89,48 @@ TEST(TestSystematics, AcceptanceBox) {
 }
 
 //------------------------------------------------------------------------------
+
+TEST(TestSystematics, AcceptanceBoxPolynomial) {
+  // Test box acceptance function that uses 2nd order polynomial
+  BinCoord x0 ({-0.6}, {-0.65}, {-0.55}); // Outside lower acceptance
+  BinCoord x1 ({0.7}, {0.6}, {0.8}); // Outside upper acceptance
+  BinCoord x2 ({0.1}, {0.0}, {0.2}); // Fully contained in acceptance
+  BinCoord x3 ({0.5}, {0.4}, {0.6}); // Contains upper limit
+  std::vector<double> c {
+    0,     // Index of relevant coordinate
+    0.5,   // Inital cut
+    0.7,   // constant polynomial term
+    10.0,  // linear polyn. term in center deviation
+    12.5,  // linear polyn. term in width deviation
+    -50.5, // quadratic polyn. term in center deviation
+    -30.5, // quadratic polyn. term in width deviation
+    -4.5   // mixed polynomial term in width and center deviations
+  };
+  std::vector<double> p_vals { 
+    0.05, // Box center deviation
+    -0.01,   // Box width deviation
+  };
+  std::vector<double*> p_ptrs {};
+  for (double & p: p_vals) { p_ptrs.push_back(&p); }
+  
+  double pred0 = 0.0;
+  double pred1 = 0.0;
+  double pred2 = 1.0;
+  double pred3 = 0.94795;
+  
+  double res0 = Systematics::acceptance_box_polynomial({x0},c,p_ptrs);
+  double res1 = Systematics::acceptance_box_polynomial({x1},c,p_ptrs);
+  double res2 = Systematics::acceptance_box_polynomial({x2},c,p_ptrs);
+  double res3 = Systematics::acceptance_box_polynomial({x3},c,p_ptrs);
+  
+  ASSERT_TRUE( Num::equal_to_eps( pred0, res0, 1e-9) ) 
+    << "(0)Expected " << pred0 << " got " << res0;
+  ASSERT_TRUE( Num::equal_to_eps( pred1, res1, 1e-9) ) 
+    << "(1)Expected " << pred1 << " got " << res1;
+  ASSERT_TRUE( Num::equal_to_eps( pred2, res2, 1e-9) ) 
+    << "(2)Expected " << pred2 << " got " << res2;
+  ASSERT_TRUE( Num::equal_to_eps( pred3, res3, 1e-9) ) 
+    << "(3)Expected " << pred3 << " got " << res3;
+}
+
+//------------------------------------------------------------------------------

--- a/source/tests/Fcts/test_Systematics.cpp
+++ b/source/tests/Fcts/test_Systematics.cpp
@@ -92,13 +92,8 @@ TEST(TestSystematics, AcceptanceBox) {
 
 TEST(TestSystematics, AcceptanceBoxPolynomial) {
   // Test box acceptance function that uses 2nd order polynomial
-  BinCoord x0 ({-0.6}, {-0.65}, {-0.55}); // Outside lower acceptance
-  BinCoord x1 ({0.7}, {0.6}, {0.8}); // Outside upper acceptance
-  BinCoord x2 ({0.1}, {0.0}, {0.2}); // Fully contained in acceptance
-  BinCoord x3 ({0.5}, {0.4}, {0.6}); // Contains upper limit
+  BinCoord x ({-0.6}, {-0.65}, {-0.55}); // Bin coordinate (has no influence)
   std::vector<double> c {
-    0,     // Index of relevant coordinate
-    0.5,   // Inital cut
     0.7,   // constant polynomial term
     10.0,  // linear polyn. term in center deviation
     12.5,  // linear polyn. term in width deviation
@@ -113,24 +108,11 @@ TEST(TestSystematics, AcceptanceBoxPolynomial) {
   std::vector<double*> p_ptrs {};
   for (double & p: p_vals) { p_ptrs.push_back(&p); }
   
-  double pred0 = 0.0;
-  double pred1 = 0.0;
-  double pred2 = 1.0;
-  double pred3 = 0.94795;
+  double pred = 0.94795;
+  double res = Systematics::acceptance_box_polynomial({x},c,p_ptrs);
   
-  double res0 = Systematics::acceptance_box_polynomial({x0},c,p_ptrs);
-  double res1 = Systematics::acceptance_box_polynomial({x1},c,p_ptrs);
-  double res2 = Systematics::acceptance_box_polynomial({x2},c,p_ptrs);
-  double res3 = Systematics::acceptance_box_polynomial({x3},c,p_ptrs);
-  
-  ASSERT_TRUE( Num::equal_to_eps( pred0, res0, 1e-9) ) 
-    << "(0)Expected " << pred0 << " got " << res0;
-  ASSERT_TRUE( Num::equal_to_eps( pred1, res1, 1e-9) ) 
-    << "(1)Expected " << pred1 << " got " << res1;
-  ASSERT_TRUE( Num::equal_to_eps( pred2, res2, 1e-9) ) 
-    << "(2)Expected " << pred2 << " got " << res2;
-  ASSERT_TRUE( Num::equal_to_eps( pred3, res3, 1e-9) ) 
-    << "(3)Expected " << pred3 << " got " << res3;
+  ASSERT_TRUE( Num::equal_to_eps( pred, res, 1e-9) ) 
+    << "Expected " << pred << " got " << res;
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
- Add a new acceptance box function with a 2nd order polynomial for bins on the edges.
- Add a test for the new polynomial acceptance box function.
- Remove the coordinate dependence from the polynomial acceptance box function (whole point was not to have this), and adjust the test of the function.