### PR TITLE
General2f parametrisation

### DIFF
--- a/source/prew/include/Fcts/FctMap.h
+++ b/source/prew/include/Fcts/FctMap.h
@@ -35,6 +35,8 @@ namespace Fcts {
     {"AsymmFactor2_3allowed", Physics::asymm_3chixs_a2},
     {"AsymmFactorLR_Af_2f", Physics::asymm_Af_2f_LR},
     {"AsymmFactorRL_Af_2f", Physics::asymm_Af_2f_RL},
+    {"General2fParam_LR", Physics::general_2f_param_LR},
+    {"General2fParam_RL", Physics::general_2f_param_RL},
     // Systematic effects
     {"PolarisationFactor", Systematics::polarisation_factor},
     {"LuminosityFraction", Systematics::luminosity_fraction},

--- a/source/prew/include/Fcts/FctMap.h
+++ b/source/prew/include/Fcts/FctMap.h
@@ -33,10 +33,12 @@ namespace Fcts {
     {"AsymmFactor0_3allowed", Physics::asymm_3chixs_a0},
     {"AsymmFactor1_3allowed", Physics::asymm_3chixs_a1},
     {"AsymmFactor2_3allowed", Physics::asymm_3chixs_a2},
-    {"AsymmFactorLR_Af_2f", Physics::asymm_Af_2f_LR},
-    {"AsymmFactorRL_Af_2f", Physics::asymm_Af_2f_RL},
     {"General2fParam_LR", Physics::general_2f_param_LR},
     {"General2fParam_RL", Physics::general_2f_param_RL},
+      /** // DEPRECATED 
+      {"AsymmFactorLR_Af_2f", Physics::asymm_Af_2f_LR},
+      {"AsymmFactorRL_Af_2f", Physics::asymm_Af_2f_RL}, 
+      **/
     // Systematic effects
     {"PolarisationFactor", Systematics::polarisation_factor},
     {"LuminosityFraction", Systematics::luminosity_fraction},

--- a/source/prew/include/Fcts/Physics.h
+++ b/source/prew/include/Fcts/Physics.h
@@ -52,6 +52,16 @@ namespace Physics {
                          const std::vector<double*>  &p);
   
   //----------------------------------------------------------------------------
+  
+  double general_2f_param_LR (const Data::BinCoord         &x,
+                              const std::vector<double>   &c,
+                              const std::vector<double*>  &p);
+  
+  double general_2f_param_RL (const Data::BinCoord         &x,
+                              const std::vector<double>   &c,
+                              const std::vector<double*>  &p);
+  
+  //----------------------------------------------------------------------------
 }
   
 }

--- a/source/prew/include/Fit/FitPar.h
+++ b/source/prew/include/Fit/FitPar.h
@@ -39,6 +39,8 @@ namespace Fit {
         bool is_fixed=false
       );
       
+      FitPar clone(const std::string &name) const;
+      
       const std::string & get_name() const; // Get name
       double get_val_ini() const;   // Get initial value
       double get_unc_ini() const;   // Get initial value

--- a/source/prew/src/Fcts/Physics.cpp
+++ b/source/prew/src/Fcts/Physics.cpp
@@ -157,7 +157,9 @@ double Physics::asymm_Af_2f_RL (
     Coordinates: x[c[1]] - cosine of polar angle in ffbar system
     Coefficients:
       c[0] - cross section in bin (completely replaced)
-      c[1] - index of cos(theta) coordinate in coordinate vector
+      c[1] - integrated LR cross section
+      c[2] - integrated RL cross section
+      c[3] - index of cos(theta) coordinate in coordinate vector
     Parameters:
       p[0] - xs0
       p[1] - Ae
@@ -172,13 +174,15 @@ double Physics::general_2f_param_LR(const Data::BinCoord &x,
                                     const std::vector<double *> &p) {
   /** LR factor of generalised difermion parametrisation (see above).
    **/
-  double x_up = x.get_edge_up()[int(c[1])];
-  double x_low = x.get_edge_low()[int(c[1])];
+  double x_up = x.get_edge_up()[int(c[3])];
+  double x_low = x.get_edge_low()[int(c[3])];
   double integral_const = x_up - x_low;
   double integral_lin = 0.5 * (std::pow(x_up, 2) - std::pow(x_low, 2));
   double integral_quad = 1.0 / 3.0 * (std::pow(x_up, 3) - std::pow(x_low, 3));
+  
+  double xs_fraction = c[0] / (c[1] + c[2]);
 
-  double factor = 3.0 / 8.0 * (*(p[0])) / c[0] * (1.0 + (*(p[1]))) / 2.0 *
+  double factor = 3.0 / 8.0 * (*(p[0])) / xs_fraction * (1.0 + (*(p[1]))) / 2.0 *
                   ((1.0 + *(p[4])) * integral_const +
                    ((*(p[3])) + 2.0 * (*(p[2]))) * integral_lin +
                    (1.0 - 3.0 * *(p[4])) * integral_quad);
@@ -193,13 +197,15 @@ double Physics::general_2f_param_RL(const Data::BinCoord &x,
                                     const std::vector<double *> &p) {
   /** RL factor of generalised difermion parametrisation (see above).
    **/                                      
-  double x_up = x.get_edge_up()[int(c[1])];
-  double x_low = x.get_edge_low()[int(c[1])];
+  double x_up = x.get_edge_up()[int(c[3])];
+  double x_low = x.get_edge_low()[int(c[3])];
   double integral_const = x_up - x_low;
   double integral_lin = 0.5 * (std::pow(x_up, 2) - std::pow(x_low, 2));
   double integral_quad = 1.0 / 3.0 * (std::pow(x_up, 3) - std::pow(x_low, 3));
+  
+  double xs_fraction = c[0] / (c[1] + c[2]);
 
-  double factor = 3.0 / 8.0 * (*(p[0])) / c[0] * (1.0 - (*(p[1]))) / 2.0 *
+  double factor = 3.0 / 8.0 * (*(p[0])) / xs_fraction * (1.0 - (*(p[1]))) / 2.0 *
                   ((1.0 + *(p[5])) * integral_const +
                    ((*(p[3])) - 2.0 * (*(p[2]))) * integral_lin +
                    (1.0 - 3.0 * *(p[5])) * integral_quad);

--- a/source/prew/src/Fcts/Physics.cpp
+++ b/source/prew/src/Fcts/Physics.cpp
@@ -149,67 +149,63 @@ double Physics::asymm_Af_2f_RL (
 
 //------------------------------------------------------------------------------
 
-double Physics::general_2f_param_LR (
-  const Data::BinCoord &x,
-  const std::vector<double>   &c,
-  const std::vector<double*>  &p
-) {
-  /**
+/** Generalised differential parametrisation in di-fermion production.
+    Derived from the helicity amplitude approach, with additional correction 
+    term to take higher order effects into account.
+    Integrates over the bin to be in agreement with the datapoint.
+    
+    Coordinates: x[c[1]] - cosine of polar angle in ffbar system
+    Coefficients:
       c[0] - cross section in bin (completely replaced)
       c[1] - index of cos(theta) coordinate in coordinate vector
-      
+    Parameters:
       p[0] - xs0
       p[1] - Ae
       p[2] - Af
-      p[3] - AR
+      p[3] - epsilon_f
       p[4] - kL
       p[5] - kR
-  **/
+**/
 
+double Physics::general_2f_param_LR(const Data::BinCoord &x,
+                                    const std::vector<double> &c,
+                                    const std::vector<double *> &p) {
+  /** LR factor of generalised difermion parametrisation (see above).
+   **/
   double x_up = x.get_edge_up()[int(c[1])];
   double x_low = x.get_edge_low()[int(c[1])];
   double integral_const = x_up - x_low;
-  double integral_lin = 0.5 * ( std::pow(x_up,2) - std::pow(x_low,2) );
-  double integral_quad = 1.0/3.0 * ( std::pow(x_up,3) - std::pow(x_low,3) );
+  double integral_lin = 0.5 * (std::pow(x_up, 2) - std::pow(x_low, 2));
+  double integral_quad = 1.0 / 3.0 * (std::pow(x_up, 3) - std::pow(x_low, 3));
 
-  double factor = (*(p[0]))/c[0] * (
-      ( (1.0 + (*(p[1])))/2.0 + (*(p[4])) ) * integral_const
-    + ( 1.0 + (*(p[3])) ) * (*(p[2])) * integral_lin
-    + ( (1.0 + (*(p[1])))/2.0 - 3.0 * (*(p[4])) ) * integral_quad
-  );
-  if (factor < 0) { factor = 0; }
+  double factor = 3.0 / 8.0 * (*(p[0])) / c[0] * (1.0 + (*(p[1]))) / 2.0 *
+                  ((1.0 + *(p[4])) * integral_const +
+                   ((*(p[3])) + 2.0 * (*(p[2]))) * integral_lin +
+                   (1.0 - 3.0 * *(p[4])) * integral_quad);
+  if (factor < 0.0) {
+    factor = 0.0;
+  }
   return factor;
 }
 
-double Physics::general_2f_param_RL (
-  const Data::BinCoord &x,
-  const std::vector<double>   &c,
-  const std::vector<double*>  &p
-) {
-  /**
-      c[0] - cross section in bin (completely replaced)
-      c[1] - index of cos(theta) coordinate in coordinate vector
-      
-      p[0] - xs0
-      p[1] - Ae
-      p[2] - Af
-      p[3] - AR
-      p[4] - kL
-      p[5] - kR
-  **/
-
+double Physics::general_2f_param_RL(const Data::BinCoord &x,
+                                    const std::vector<double> &c,
+                                    const std::vector<double *> &p) {
+  /** RL factor of generalised difermion parametrisation (see above).
+   **/                                      
   double x_up = x.get_edge_up()[int(c[1])];
   double x_low = x.get_edge_low()[int(c[1])];
   double integral_const = x_up - x_low;
-  double integral_lin = 0.5 * ( std::pow(x_up,2) - std::pow(x_low,2) );
-  double integral_quad = 1.0/3.0 * ( std::pow(x_up,3) - std::pow(x_low,3) );
+  double integral_lin = 0.5 * (std::pow(x_up, 2) - std::pow(x_low, 2));
+  double integral_quad = 1.0 / 3.0 * (std::pow(x_up, 3) - std::pow(x_low, 3));
 
-  double factor = (*(p[0]))/c[0] * (
-      ( (1.0 - (*(p[1])))/2.0 + (*(p[5])) ) * integral_const
-    - ( 1.0 - (*(p[3])) ) * (*(p[2])) * integral_lin
-    + ( (1.0 - (*(p[1])))/2.0 - 3.0 * (*(p[5])) ) * integral_quad
-  );
-  if (factor < 0) { factor = 0; }
+  double factor = 3.0 / 8.0 * (*(p[0])) / c[0] * (1.0 - (*(p[1]))) / 2.0 *
+                  ((1.0 + *(p[5])) * integral_const +
+                   ((*(p[3])) - 2.0 * (*(p[2]))) * integral_lin +
+                   (1.0 - 3.0 * *(p[5])) * integral_quad);
+  if (factor < 0.0) {
+    factor = 0.0;
+  }
   return factor;
 }
 

--- a/source/prew/src/Fcts/Physics.cpp
+++ b/source/prew/src/Fcts/Physics.cpp
@@ -149,5 +149,71 @@ double Physics::asymm_Af_2f_RL (
 
 //------------------------------------------------------------------------------
 
+double Physics::general_2f_param_LR (
+  const Data::BinCoord &x,
+  const std::vector<double>   &c,
+  const std::vector<double*>  &p
+) {
+  /**
+      c[0] - cross section in bin (completely replaced)
+      c[1] - index of cos(theta) coordinate in coordinate vector
+      
+      p[0] - xs0
+      p[1] - Ae
+      p[2] - Af
+      p[3] - AR
+      p[4] - kL
+      p[5] - kR
+  **/
+
+  double x_up = x.get_edge_up()[int(c[1])];
+  double x_low = x.get_edge_low()[int(c[1])];
+  double integral_const = x_up - x_low;
+  double integral_lin = 0.5 * ( std::pow(x_up,2) - std::pow(x_low,2) );
+  double integral_quad = 1.0/3.0 * ( std::pow(x_up,3) - std::pow(x_low,3) );
+
+  double factor = (*(p[0]))/c[0] * (
+      ( (1.0 + (*(p[1])))/2.0 + (*(p[4])) ) * integral_const
+    + ( 1.0 + (*(p[3])) ) * (*(p[2])) * integral_lin
+    + ( (1.0 + (*(p[1])))/2.0 - 3.0 * (*(p[4])) ) * integral_quad
+  );
+  if (factor < 0) { factor = 0; }
+  return factor;
+}
+
+double Physics::general_2f_param_RL (
+  const Data::BinCoord &x,
+  const std::vector<double>   &c,
+  const std::vector<double*>  &p
+) {
+  /**
+      c[0] - cross section in bin (completely replaced)
+      c[1] - index of cos(theta) coordinate in coordinate vector
+      
+      p[0] - xs0
+      p[1] - Ae
+      p[2] - Af
+      p[3] - AR
+      p[4] - kL
+      p[5] - kR
+  **/
+
+  double x_up = x.get_edge_up()[int(c[1])];
+  double x_low = x.get_edge_low()[int(c[1])];
+  double integral_const = x_up - x_low;
+  double integral_lin = 0.5 * ( std::pow(x_up,2) - std::pow(x_low,2) );
+  double integral_quad = 1.0/3.0 * ( std::pow(x_up,3) - std::pow(x_low,3) );
+
+  double factor = (*(p[0]))/c[0] * (
+      ( (1.0 - (*(p[1])))/2.0 + (*(p[5])) ) * integral_const
+    - ( 1.0 - (*(p[3])) ) * (*(p[2])) * integral_lin
+    + ( (1.0 - (*(p[1])))/2.0 - 3.0 * (*(p[5])) ) * integral_quad
+  );
+  if (factor < 0) { factor = 0; }
+  return factor;
+}
+
+//------------------------------------------------------------------------------
+
 } // Namespace Fcts
 } // Namespace PrEW

--- a/source/prew/src/Fit/FitPar.cpp
+++ b/source/prew/src/Fit/FitPar.cpp
@@ -19,6 +19,22 @@ FitPar::FitPar(
   m_val_mod = m_val_ini;
 }
 
+FitPar FitPar::clone(const std::string &name) const {
+  /** Clone this FitPar into a new one that has all the same values and only
+      changes the name.
+   **/
+  auto new_par = FitPar(name, m_val_ini, m_unc_ini, m_is_fixed);
+  new_par.m_val_mod = m_val_mod;
+  if (this->is_limited()) {
+    new_par.set_limits(this->get_lower_lim(),this->get_upper_lim());
+  }
+  
+  if (this->has_constraint()) {
+    new_par.set_constrgauss(this->get_constr_val(),this->get_constr_unc());
+  }
+  return new_par;
+}
+
 //------------------------------------------------------------------------------
 // get functions
 

--- a/source/tests/Fcts/test_Physics.cpp
+++ b/source/tests/Fcts/test_Physics.cpp
@@ -110,3 +110,23 @@ TEST(TestPhysics, AsymmFactors_Af_2f) {
 }
 
 //------------------------------------------------------------------------------
+
+TEST(TestPhysics, General2fParam) {
+  // Test the general 2f parametrisation
+  BinCoord x {{0.45}, {0.4}, {0.5}};
+  std::vector<double> c {250.,0};
+  std::vector<double> p_vals {2000,0.7,0.3,-0.3,0.1,-0.1};
+  double res_LR = 0.3512199999999999;
+  double res_RL = 0.03417;
+  
+  std::vector<double*> p_ptrs {};
+  for (double & p: p_vals) { p_ptrs.push_back(&p); }
+  
+  ASSERT_TRUE(Num::equal_to_eps(Physics::general_2f_param_LR(x,c,p_ptrs), res_LR))
+    << "Expected " << res_LR << " got " << Physics::general_2f_param_LR(x,c,p_ptrs);
+  
+  ASSERT_TRUE(Num::equal_to_eps(Physics::general_2f_param_RL(x,c,p_ptrs), res_RL))
+    << "Expected " << res_RL << " got " << Physics::general_2f_param_RL(x,c,p_ptrs);
+}
+
+//------------------------------------------------------------------------------

--- a/source/tests/Fcts/test_Physics.cpp
+++ b/source/tests/Fcts/test_Physics.cpp
@@ -114,10 +114,10 @@ TEST(TestPhysics, AsymmFactors_Af_2f) {
 TEST(TestPhysics, General2fParam) {
   // Test the general 2f parametrisation
   BinCoord x {{0.45}, {0.4}, {0.5}};
-  std::vector<double> c {250.,0};
-  std::vector<double> p_vals {2000,0.7,0.3,-0.3,0.1,-0.1};
-  double res_LR = 0.3512199999999999;
-  double res_RL = 0.03417;
+  std::vector<double> c {2.5e4,2.7e7,0.3e7,0};
+  std::vector<double> p_vals {1.1,0.7,0.3,-0.3,0.1,-0.1};
+  double res_LR = 57.95129999999999;
+  double res_RL = 5.63805;
   
   std::vector<double*> p_ptrs {};
   for (double & p: p_vals) { p_ptrs.push_back(&p); }

--- a/source/tests/Fit/test_FitPar.cpp
+++ b/source/tests/Fit/test_FitPar.cpp
@@ -127,3 +127,23 @@ TEST(TestFitPar, LimitSetting) {
   ASSERT_EQ(fp.get_lower_lim(), -1.5);
   ASSERT_EQ(fp.get_upper_lim(), 1000);
 }
+
+TEST(TestFitPar, Cloning) {
+  FitPar fp1 ("fp1", 0.1, 0.001, false);
+  fp1.set_limits(0.,2.);
+  fp1.set_constrgauss(0.1,0.05);
+  
+  auto fp2 = fp1.clone("fp2");
+  ASSERT_FALSE(fp1 == fp2);
+  ASSERT_STREQ(fp1.get_name().c_str(), "fp1");
+  ASSERT_STREQ(fp2.get_name().c_str(), "fp2");
+  ASSERT_EQ(fp1.m_val_mod, fp2.m_val_mod);
+  ASSERT_EQ(fp1.get_val_ini(), fp2.get_val_ini());
+  ASSERT_EQ(fp1.get_unc_ini(), fp2.get_unc_ini());
+  ASSERT_EQ(fp1.is_limited(), fp2.is_limited());
+  ASSERT_EQ(fp1.get_lower_lim(), fp2.get_lower_lim());
+  ASSERT_EQ(fp1.get_upper_lim(), fp2.get_upper_lim());
+  ASSERT_EQ(fp1.has_constraint(), fp2.has_constraint());
+  ASSERT_EQ(fp1.get_constr_val(), fp2.get_constr_val());
+  ASSERT_EQ(fp1.get_constr_unc(), fp2.get_constr_unc());
+}


### PR DESCRIPTION
- Add a first rough try for a general 2f parametrisation (untested!).
- Update the generalised 2f parametrisation to the new parametrisation.
- Add a test for the generalised 2f parametrisation.
- Deprecate old 2f parametrisations that are not safe to use by removing them from the function map.
- Use a relative total cross section parameter in the 2f general parametrisation to avoid very large parameter values.
- Add parameter cloning functionality and an according test.